### PR TITLE
Add support for patches using VCDIFF

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -104,3 +104,13 @@ http_archive(
     urls = ["https://github.com/PJK/libcbor/archive/refs/tags/v0.8.0.zip"],
 )
 
+# open-vcdiff
+http_archive(
+    name = "open-vcdiff",
+    build_file = "//third_party:open-vcdiff.BUILD",
+    sha256 = "39ce3a95f72ba7b64e8054d95e741fc3c69abddccf9f83868a7f52f3ae2174c0",
+    strip_prefix = "open-vcdiff-868f459a8d815125c2457f8c74b12493853100f9",
+    urls = ["https://github.com/google/open-vcdiff/archive/868f459a8d815125c2457f8c74b12493853100f9.zip"],
+)
+
+

--- a/patch_subset/BUILD
+++ b/patch_subset/BUILD
@@ -47,6 +47,7 @@ cc_library(
         "brotli_request_logger.cc",
         "memory_request_logger.cc",
         "patch_subset_client.cc",
+        "vcdiff_binary_patch.cc",
     ],
     hdrs = [
         "binary_patch.h",
@@ -56,6 +57,7 @@ cc_library(
         "null_request_logger.h",
         "patch_subset_client.h",
         "request_logger.h",
+        "vcdiff_binary_patch.h",
     ],
     visibility = [
         "//visibility:public",
@@ -67,6 +69,7 @@ cc_library(
         "@brotli//:brotlidec",
         "@com_google_absl//absl/strings",
         "@harfbuzz",
+        "@open-vcdiff//:vcddec",
     ],
 )
 
@@ -91,6 +94,7 @@ cc_library(
         "file_font_provider.cc",
         "hb_set_unique_ptr.cc",
         "sparse_bit_set.cc",
+        "vcdiff_binary_diff.cc",
     ],
     hdrs = [
         "binary_diff.h",
@@ -105,6 +109,7 @@ cc_library(
         "hb_set_unique_ptr.h",
         "patch_subset_server.h",
         "sparse_bit_set.h",
+        "vcdiff_binary_diff.h",
     ],
     visibility = [
         "//visibility:public",
@@ -117,6 +122,7 @@ cc_library(
         "@com_google_absl//absl/types:optional",
         "@fasthash",
         "@harfbuzz",
+        "@open-vcdiff//:vcdenc",
     ],
 )
 
@@ -138,14 +144,15 @@ cc_test(
         "mock_binary_patch.h",
         "mock_codepoint_predictor.h",
         "mock_font_provider.h",
-        "mock_integer_list_checksum.h",
         "mock_hasher.h",
+        "mock_integer_list_checksum.h",
         "mock_patch_subset_server.h",
         "patch_subset_client_test.cc",
         "patch_subset_server_impl_test.cc",
         "server_integration_test.cc",
         "simple_codepoint_mapper_test.cc",
         "sparse_bit_set_test.cc",
+        "vcdiff_patching_test.cc",
     ],
     data = [
         ":testdata",

--- a/patch_subset/client_server_integration_test.cc
+++ b/patch_subset/client_server_integration_test.cc
@@ -14,6 +14,7 @@
 #include "patch_subset/patch_subset_client.h"
 #include "patch_subset/patch_subset_server_impl.h"
 #include "patch_subset/simple_codepoint_mapper.h"
+#include "patch_subset/vcdiff_binary_diff.h"
 
 using ::absl::string_view;
 using patch_subset::cbor::ClientState;
@@ -32,6 +33,7 @@ class PatchSubsetClientServerIntegrationTest : public ::testing::Test {
             std::unique_ptr<FontProvider>(new FileFontProvider(kTestDataDir)),
             std::unique_ptr<Subsetter>(new HarfbuzzSubsetter()),
             std::unique_ptr<BinaryDiff>(new BrotliBinaryDiff()),
+            std::unique_ptr<BinaryDiff>(new VCDIFFBinaryDiff()),
             std::unique_ptr<Hasher>(new FastHasher()),
             std::unique_ptr<CodepointMapper>(nullptr),
             std::unique_ptr<IntegerListChecksum>(nullptr),
@@ -45,6 +47,7 @@ class PatchSubsetClientServerIntegrationTest : public ::testing::Test {
             std::unique_ptr<FontProvider>(new FileFontProvider(kTestDataDir)),
             std::unique_ptr<Subsetter>(new HarfbuzzSubsetter()),
             std::unique_ptr<BinaryDiff>(new BrotliBinaryDiff()),
+            std::unique_ptr<BinaryDiff>(new VCDIFFBinaryDiff()),
             std::unique_ptr<Hasher>(new FastHasher()),
             std::unique_ptr<CodepointMapper>(new SimpleCodepointMapper()),
             std::unique_ptr<IntegerListChecksum>(

--- a/patch_subset/patch_subset_server_impl.cc
+++ b/patch_subset/patch_subset_server_impl.cc
@@ -82,7 +82,6 @@ StatusCode PatchSubsetServerImpl::Handle(const std::string& font_id,
 
   ValidatePatchBase(request.BaseChecksum(), &state);
 
-  // TODO(garretrieger): add multiple binary diff support, including vcdiff.
   const BinaryDiff* binary_diff =
       DiffFor(request.AcceptFormats(), state.format);
   if (!binary_diff) {
@@ -95,7 +94,6 @@ StatusCode PatchSubsetServerImpl::Handle(const std::string& font_id,
     return result;
   }
 
-  // TODO(garretrieger): check which diffs the client supports.
   // TODO(garretrieger): handle exceptional cases (see design doc).
 
   ConstructResponse(state, response);

--- a/patch_subset/patch_subset_server_impl.h
+++ b/patch_subset/patch_subset_server_impl.h
@@ -167,7 +167,8 @@ class PatchSubsetServerImpl : public PatchSubsetServer {
   bool Check(StatusCode result) const;
   bool Check(StatusCode result, const std::string& message) const;
 
-  const BinaryDiff* DiffFor(const std::vector<PatchFormat>& formats) const;
+  const BinaryDiff* DiffFor(const std::vector<PatchFormat>& formats,
+                            PatchFormat& format /* OUT */) const;
 
   int max_predicted_codepoints_;
   std::unique_ptr<FontProvider> font_provider_;

--- a/patch_subset/server_integration_test.cc
+++ b/patch_subset/server_integration_test.cc
@@ -9,6 +9,8 @@
 #include "patch_subset/hb_set_unique_ptr.h"
 #include "patch_subset/noop_codepoint_predictor.h"
 #include "patch_subset/patch_subset_server_impl.h"
+#include "patch_subset/vcdiff_binary_diff.h"
+#include "patch_subset/vcdiff_binary_patch.h"
 
 using ::absl::string_view;
 using patch_subset::cbor::PatchRequest;
@@ -20,11 +22,11 @@ class PatchSubsetServerIntegrationTest : public ::testing::Test {
  protected:
   PatchSubsetServerIntegrationTest()
       : font_provider_(new FileFontProvider("patch_subset/testdata/")),
-        binary_diff_(new BrotliBinaryDiff()),
         server_(
             0, std::unique_ptr<FontProvider>(font_provider_),
             std::unique_ptr<Subsetter>(new HarfbuzzSubsetter()),
-            std::unique_ptr<BinaryDiff>(binary_diff_),
+            std::unique_ptr<BinaryDiff>(new BrotliBinaryDiff()),
+            std::unique_ptr<BinaryDiff>(new VCDIFFBinaryDiff()),
             std::unique_ptr<Hasher>(new FastHasher()),
             std::unique_ptr<CodepointMapper>(nullptr),
             std::unique_ptr<IntegerListChecksum>(nullptr),
@@ -42,24 +44,37 @@ class PatchSubsetServerIntegrationTest : public ::testing::Test {
   }
 
   void CheckPatch(const FontData& base, const FontData& target,
-                  string_view patch_string) {
+                  string_view patch_string,
+                  PatchFormat format = PatchFormat::BROTLI_SHARED_DICT) {
+    std::unique_ptr<BinaryDiff> binary_diff;
+    std::unique_ptr<BinaryPatch> binary_patch;
+    switch (format) {
+      case BROTLI_SHARED_DICT:
+        binary_diff = std::unique_ptr<BinaryDiff>(new BrotliBinaryDiff());
+        binary_patch = std::unique_ptr<BinaryPatch>(new BrotliBinaryPatch());
+        break;
+      case VCDIFF:
+        binary_diff = std::unique_ptr<BinaryDiff>(new VCDIFFBinaryDiff());
+        binary_patch = std::unique_ptr<BinaryPatch>(new VCDIFFBinaryPatch());
+        break;
+    }
+
     // Check that diff base and target produces patch,
     // and that applying patch to base produces target.
-    BrotliBinaryDiff binary_diff;
     FontData expected_patch;
-    EXPECT_EQ(binary_diff.Diff(base, target, &expected_patch), StatusCode::kOk);
+    EXPECT_EQ(binary_diff->Diff(base, target, &expected_patch),
+              StatusCode::kOk);
     EXPECT_EQ(patch_string, expected_patch.str());
 
     FontData actual_target;
     FontData patch;
-    BrotliBinaryPatch binary_patch;
     patch.copy(patch_string.data(), patch_string.size());
-    EXPECT_EQ(binary_patch.Patch(base, patch, &actual_target), StatusCode::kOk);
+    EXPECT_EQ(binary_patch->Patch(base, patch, &actual_target),
+              StatusCode::kOk);
     EXPECT_EQ(actual_target.str(), target.str());
   }
 
   FontProvider* font_provider_;
-  BinaryDiff* binary_diff_;
   PatchSubsetServerImpl server_;
 
   FontData empty_;
@@ -78,6 +93,7 @@ TEST_F(PatchSubsetServerIntegrationTest, NewRequest) {
   patch_subset::cbor::CompressedSet codepoints_needed;
   CompressedSet::Encode(*set_abcd, codepoints_needed);
   request.SetCodepointsNeeded(codepoints_needed);
+  request.SetAcceptFormats({PatchFormat::BROTLI_SHARED_DICT});
 
   PatchResponse response;
   EXPECT_EQ(server_.Handle("Roboto-Regular.ttf", request, response),
@@ -88,6 +104,26 @@ TEST_F(PatchSubsetServerIntegrationTest, NewRequest) {
   EXPECT_EQ(response.GetPatchFormat(), PatchFormat::BROTLI_SHARED_DICT);
 
   CheckPatch(empty_, roboto_abcd_, response.Replacement());
+}
+
+TEST_F(PatchSubsetServerIntegrationTest, NewRequestVCDIFF) {
+  hb_set_unique_ptr set_abcd = make_hb_set_from_ranges(1, 0x61, 0x64);
+
+  PatchRequest request;
+  patch_subset::cbor::CompressedSet codepoints_needed;
+  CompressedSet::Encode(*set_abcd, codepoints_needed);
+  request.SetCodepointsNeeded(codepoints_needed);
+  request.SetAcceptFormats({PatchFormat::VCDIFF});
+
+  PatchResponse response;
+  EXPECT_EQ(server_.Handle("Roboto-Regular.ttf", request, response),
+            StatusCode::kOk);
+
+  EXPECT_EQ(response.OriginalFontChecksum(), original_font_checksum);
+  EXPECT_EQ(response.PatchedChecksum(), subset_abcd_checksum);
+  EXPECT_EQ(response.GetPatchFormat(), PatchFormat::VCDIFF);
+
+  CheckPatch(empty_, roboto_abcd_, response.Replacement(), PatchFormat::VCDIFF);
 }
 
 TEST_F(PatchSubsetServerIntegrationTest, PatchRequest) {
@@ -103,6 +139,7 @@ TEST_F(PatchSubsetServerIntegrationTest, PatchRequest) {
   CompressedSet::Encode(*set_abcd, codepoints_needed);
   request.SetCodepointsNeeded(codepoints_needed);
 
+  request.SetAcceptFormats({PatchFormat::BROTLI_SHARED_DICT});
   request.SetOriginalFontChecksum(original_font_checksum);
   request.SetBaseChecksum(subset_ab_checksum);
 
@@ -115,6 +152,34 @@ TEST_F(PatchSubsetServerIntegrationTest, PatchRequest) {
   EXPECT_EQ(response.GetPatchFormat(), PatchFormat::BROTLI_SHARED_DICT);
 
   CheckPatch(roboto_ab_, roboto_abcd_, response.Patch());
+}
+
+TEST_F(PatchSubsetServerIntegrationTest, PatchRequestVCDIFF) {
+  hb_set_unique_ptr set_ab = make_hb_set_from_ranges(1, 0x61, 0x62);
+  hb_set_unique_ptr set_abcd = make_hb_set_from_ranges(1, 0x61, 0x64);
+
+  PatchRequest request;
+  patch_subset::cbor::CompressedSet codepoints_have;
+  CompressedSet::Encode(*set_ab, codepoints_have);
+  request.SetCodepointsHave(codepoints_have);
+
+  patch_subset::cbor::CompressedSet codepoints_needed;
+  CompressedSet::Encode(*set_abcd, codepoints_needed);
+  request.SetCodepointsNeeded(codepoints_needed);
+
+  request.SetAcceptFormats({PatchFormat::VCDIFF});
+  request.SetOriginalFontChecksum(original_font_checksum);
+  request.SetBaseChecksum(subset_ab_checksum);
+
+  PatchResponse response;
+  EXPECT_EQ(server_.Handle("Roboto-Regular.ttf", request, response),
+            StatusCode::kOk);
+
+  EXPECT_EQ(response.OriginalFontChecksum(), original_font_checksum);
+  EXPECT_EQ(response.PatchedChecksum(), subset_abcd_checksum);
+  EXPECT_EQ(response.GetPatchFormat(), PatchFormat::VCDIFF);
+
+  CheckPatch(roboto_ab_, roboto_abcd_, response.Patch(), PatchFormat::VCDIFF);
 }
 
 TEST_F(PatchSubsetServerIntegrationTest, BadOriginalChecksum) {
@@ -131,6 +196,7 @@ TEST_F(PatchSubsetServerIntegrationTest, BadOriginalChecksum) {
   CompressedSet::Encode(*set_abcd, codepoints_needed);
   request.SetCodepointsNeeded(codepoints_needed);
 
+  request.SetAcceptFormats({PatchFormat::BROTLI_SHARED_DICT});
   request.SetOriginalFontChecksum(0);
   request.SetBaseChecksum(subset_ab_checksum);
 
@@ -156,6 +222,7 @@ TEST_F(PatchSubsetServerIntegrationTest, BadBaseChecksum) {
   patch_subset::cbor::CompressedSet codepoints_needed;
   CompressedSet::Encode(*set_abcd, codepoints_needed);
   request.SetCodepointsNeeded(codepoints_needed);
+  request.SetAcceptFormats({PatchFormat::BROTLI_SHARED_DICT});
   request.SetOriginalFontChecksum(original_font_checksum);
   request.SetBaseChecksum(0);
 

--- a/patch_subset/vcdiff_binary_diff.cc
+++ b/patch_subset/vcdiff_binary_diff.cc
@@ -1,0 +1,28 @@
+#include "patch_subset/vcdiff_binary_diff.h"
+
+#include <vector>
+
+#include "common/logging.h"
+#include "common/status.h"
+#include "google/vcencoder.h"
+#include "patch_subset/font_data.h"
+
+using ::absl::string_view;
+
+namespace patch_subset {
+
+StatusCode VCDIFFBinaryDiff::Diff(const FontData& font_base,
+                                  const FontData& font_derived,
+                                  FontData* patch /* OUT */) const {
+  open_vcdiff::VCDiffEncoder encoder(font_base.data(), font_base.size());
+  encoder.SetFormatFlags(open_vcdiff::VCD_STANDARD_FORMAT);
+  std::string diff;
+  if (!encoder.Encode(font_derived.data(), font_derived.size(), &diff))
+    return StatusCode::kInternal;
+
+  patch->copy(diff.c_str(), diff.size());
+
+  return StatusCode::kOk;
+}
+
+}  // namespace patch_subset

--- a/patch_subset/vcdiff_binary_diff.h
+++ b/patch_subset/vcdiff_binary_diff.h
@@ -1,0 +1,20 @@
+#ifndef PATCH_SUBSET_VCDIFF_BINARY_DIFF_H_
+#define PATCH_SUBSET_VCDIFF_BINARY_DIFF_H_
+
+#include "common/status.h"
+#include "patch_subset/binary_diff.h"
+#include "patch_subset/font_data.h"
+
+namespace patch_subset {
+
+// Computes a binary diff using VCDIFF
+// (https://datatracker.ietf.org/doc/html/rfc3284)
+class VCDIFFBinaryDiff : public BinaryDiff {
+ public:
+  StatusCode Diff(const FontData& font_base, const FontData& font_derived,
+                  FontData* patch /* OUT */) const override;
+};
+
+}  // namespace patch_subset
+
+#endif  // PATCH_SUBSET_VCDIFF_BINARY_DIFF_H_

--- a/patch_subset/vcdiff_binary_patch.cc
+++ b/patch_subset/vcdiff_binary_patch.cc
@@ -1,0 +1,27 @@
+#include "patch_subset/vcdiff_binary_patch.h"
+
+#include <vector>
+
+#include "common/logging.h"
+#include "common/status.h"
+#include "google/vcdecoder.h"
+#include "patch_subset/binary_patch.h"
+#include "patch_subset/font_data.h"
+
+using ::absl::string_view;
+
+namespace patch_subset {
+
+StatusCode VCDIFFBinaryPatch::Patch(const FontData& font_base,
+                                    const FontData& patch,
+                                    FontData* font_derived /* OUT */) const {
+  open_vcdiff::VCDiffDecoder decoder;
+  std::string result;
+  if (!decoder.Decode(font_base.data(), font_base.size(), patch.string(),
+                      &result))
+    return StatusCode::kInvalidArgument;
+  font_derived->copy(result.c_str(), result.size());
+  return StatusCode::kOk;
+}
+
+}  // namespace patch_subset

--- a/patch_subset/vcdiff_binary_patch.h
+++ b/patch_subset/vcdiff_binary_patch.h
@@ -1,0 +1,19 @@
+#ifndef PATCH_SUBSET_VCDIFF_BINARY_PATCH_H_
+#define PATCH_SUBSET_VCDIFF_BINARY_PATCH_H_
+
+#include "common/status.h"
+#include "patch_subset/binary_patch.h"
+#include "patch_subset/font_data.h"
+
+namespace patch_subset {
+
+// Applies a patch that was created using vcdiff.
+class VCDIFFBinaryPatch : public BinaryPatch {
+ public:
+  StatusCode Patch(const FontData& font_base, const FontData& patch,
+                   FontData* font_derived /* OUT */) const override;
+};
+
+}  // namespace patch_subset
+
+#endif  // PATCH_SUBSET_VCDIFF_BINARY_PATCH_H_

--- a/patch_subset/vcdiff_patching_test.cc
+++ b/patch_subset/vcdiff_patching_test.cc
@@ -1,0 +1,67 @@
+#include "absl/types/span.h"
+#include "common/status.h"
+#include "gtest/gtest.h"
+#include "patch_subset/file_font_provider.h"
+#include "patch_subset/font_provider.h"
+#include "patch_subset/vcdiff_binary_diff.h"
+#include "patch_subset/vcdiff_binary_patch.h"
+
+using ::absl::Span;
+
+namespace patch_subset {
+
+class VCDIFFPatchingTest : public ::testing::Test {
+ protected:
+  VCDIFFPatchingTest()
+      : font_provider_(new FileFontProvider("patch_subset/testdata/")),
+        diff_(new VCDIFFBinaryDiff()),
+        patch_(new VCDIFFBinaryPatch()) {}
+
+  ~VCDIFFPatchingTest() override {}
+
+  void SetUp() override {
+    EXPECT_EQ(font_provider_->GetFont("Roboto-Regular.Meows.ttf", &subset_a_),
+              StatusCode::kOk);
+    EXPECT_EQ(font_provider_->GetFont("Roboto-Regular.Awesome.ttf", &subset_b_),
+              StatusCode::kOk);
+    EXPECT_GT(subset_a_.size(), 0);
+    EXPECT_GT(subset_b_.size(), 0);
+  }
+
+  std::unique_ptr<FontProvider> font_provider_;
+  std::unique_ptr<BinaryDiff> diff_;
+  std::unique_ptr<BinaryPatch> patch_;
+  FontData subset_a_;
+  FontData subset_b_;
+};
+
+TEST_F(VCDIFFPatchingTest, DiffAndPatchPatchWithEmptyBase) {
+  FontData empty;
+  FontData patch;
+  EXPECT_EQ(diff_->Diff(empty, subset_a_, &patch), StatusCode::kOk);
+
+  EXPECT_GT(patch.size(), 0);
+  EXPECT_LT(patch.size(), subset_a_.size());
+  EXPECT_NE(Span<const char>(patch), Span<const char>(subset_a_));
+
+  FontData patched;
+  EXPECT_EQ(patch_->Patch(empty, patch, &patched), StatusCode::kOk);
+  EXPECT_EQ(Span<const char>(patched), Span<const char>(subset_a_));
+}
+
+TEST_F(VCDIFFPatchingTest, DiffAndPatch) {
+  FontData patch;
+  EXPECT_EQ(diff_->Diff(subset_a_, subset_b_, &patch), StatusCode::kOk);
+
+  EXPECT_GT(patch.size(), 0);
+  EXPECT_LT(patch.size(), subset_a_.size());
+  EXPECT_LT(patch.size(), subset_b_.size());
+  EXPECT_NE(Span<const char>(patch), Span<const char>(subset_a_));
+  EXPECT_NE(Span<const char>(patch), Span<const char>(subset_b_));
+
+  FontData patched;
+  EXPECT_EQ(patch_->Patch(subset_a_, patch, &patched), StatusCode::kOk);
+  EXPECT_EQ(Span<const char>(patched), Span<const char>(subset_b_));
+}
+
+}  // namespace patch_subset

--- a/third_party/open-vcdiff.BUILD
+++ b/third_party/open-vcdiff.BUILD
@@ -1,0 +1,71 @@
+cc_library(
+    name = "vcdcom",
+    srcs = [
+        "src/addrcache.cc",
+        "src/codetable.cc",
+        "src/logging.cc",
+        "src/varint_bigendian.cc",
+        "src/zlib/adler32.c",
+    ],
+    deps = [
+      "@w3c_patch_subset_incxfer//third_party/open-vcdiff:config",
+    ],
+    hdrs = [
+        "src/addrcache.h",
+        "src/checksum.h",
+        "src/codetable.h",
+        "src/google/output_string.h",
+        "src/logging.h",
+        "src/unique_ptr.h",
+        "src/varint_bigendian.h",
+        "src/vcdiff_defs.h",
+        "src/zlib/zconf.h",
+        "src/zlib/zlib.h",
+    ],
+    includes = [
+        "src",
+        "src/zlib",
+    ],
+)
+
+cc_library(
+    name = "vcddec",
+    srcs = [
+        "src/decodetable.cc",
+        "src/headerparser.cc",
+        "src/vcdecoder.cc",
+    ],
+    hdrs = [
+        "src/decodetable.h",
+        "src/google/vcdecoder.h",
+        "src/headerparser.h",
+    ],
+    deps = [":vcdcom"],
+)
+
+cc_library(
+    name = "vcdenc",
+    srcs = [
+        "src/blockhash.cc",
+        "src/encodetable.cc",
+        "src/instruction_map.cc",
+        "src/jsonwriter.cc",
+        "src/vcdiffengine.cc",
+        "src/vcencoder.cc",
+    ],
+    hdrs = [
+        "src/blockhash.h",
+        "src/compile_assert.h",
+        "src/google/format_extension_flags.h",
+        "src/google/vcencoder.h",
+        "src/google/encodetable.h",
+        "src/google/jsonwriter.h",
+	"src/google/codetablewriter_interface.h",
+        "src/instruction_map.h",
+        "src/rolling_hash.h",
+        "src/vcdiffengine.h",
+    ],
+    deps = [":vcdcom"],
+    visibility = ["//visibility:public"],
+)
+

--- a/third_party/open-vcdiff.BUILD
+++ b/third_party/open-vcdiff.BUILD
@@ -41,6 +41,7 @@ cc_library(
         "src/headerparser.h",
     ],
     deps = [":vcdcom"],
+     visibility = ["//visibility:public"],
 )
 
 cc_library(

--- a/third_party/open-vcdiff/BUILD
+++ b/third_party/open-vcdiff/BUILD
@@ -1,0 +1,10 @@
+cc_library(
+    name = "config",
+    hdrs = [
+        "config.h",
+    ],
+    includes = [
+        "./",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/third_party/open-vcdiff/config.h
+++ b/third_party/open-vcdiff/config.h
@@ -1,0 +1,53 @@
+// Copyright 2016 The open-vcdiff Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* Defined to PROJECT_VERSION from CMakeLists.txt */
+#define OPEN_VCDIFF_VERSION "0.8.4"
+
+/* Define to 1 if you have the <ext/rope> header file. */
+/* #undef HAVE_EXT_ROPE */
+
+/* Define to 1 if you have the `gettimeofday' function. */
+#define HAVE_GETTIMEOFDAY
+
+/* Define to 1 if you have the <malloc.h> header file. */
+#define HAVE_MALLOC_H
+
+/* Define to 1 if you have the `memalign' function. */
+#define HAVE_MEMALIGN
+
+/* Define to 1 if you have the `mprotect' function. */
+#define HAVE_MPROTECT
+
+/* Define to 1 if you have the `posix_memalign' function. */
+#define HAVE_POSIX_MEMALIGN
+
+/* Define to 1 if you have the <sys/mman.h> header file. */
+#define HAVE_SYS_MMAN_H
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+/* #undef HAVE_SYS_STAT_H */
+
+/* Define to 1 if you have the <sys/time.h> header file. */
+#define HAVE_SYS_TIME_H
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#define HAVE_UNISTD_H
+
+/* Define to 1 if you have the <windows.h> header file. */
+/* #undef HAVE_WINDOWS_H */
+
+/* Use custom compare function instead of memcmp */
+/* #undef VCDIFF_USE_BLOCK_COMPARE_WORDS */
+

--- a/third_party/open-vcdiff/config.h
+++ b/third_party/open-vcdiff/config.h
@@ -50,4 +50,3 @@
 
 /* Use custom compare function instead of memcmp */
 /* #undef VCDIFF_USE_BLOCK_COMPARE_WORDS */
-


### PR DESCRIPTION
The spec requires all implementations to support at least VCDIFF as a patch format. This adds support for VCDIFF in addition to the currently used brotli diff.