### PR TITLE
Reject requests that are missing required checksums or protocol version.

### DIFF
--- a/patch_subset/patch_subset_client.cc
+++ b/patch_subset/patch_subset_client.cc
@@ -161,6 +161,7 @@ void PatchSubsetClient::CreateRequest(const hb_set_t& codepoints_have,
                                       const hb_set_t& codepoints_needed,
                                       const ClientState& state,
                                       PatchRequest* request) {
+  request->SetProtocolVersion(ProtocolVersion::ONE);
   if (hb_set_get_population(&codepoints_have)) {
     request->SetOriginalFontChecksum(state.OriginalFontChecksum());
     request->SetBaseChecksum(hasher_->Checksum(state.FontData()));

--- a/patch_subset/patch_subset_client_test.cc
+++ b/patch_subset/patch_subset_client_test.cc
@@ -48,12 +48,14 @@ class PatchSubsetClientTest : public ::testing::Test {
     CompressedSet::Encode(codepoints, codepoints_needed);
     request.SetCodepointsNeeded(codepoints_needed);
     request.AddAcceptFormat(PatchFormat::BROTLI_SHARED_DICT);
+    request.SetProtocolVersion(ProtocolVersion::ONE);
     return request;
   }
 
   PatchRequest CreateRequest(const hb_set_t& codepoints_have,
                              const hb_set_t& codepoints_needed) {
     PatchRequest request;
+    request.SetProtocolVersion(ProtocolVersion::ONE);
     if (!hb_set_is_empty(&codepoints_have)) {
       patch_subset::cbor::CompressedSet codepoints_have2;
       CompressedSet::Encode(codepoints_have, codepoints_have2);

--- a/patch_subset/patch_subset_server_impl.h
+++ b/patch_subset/patch_subset_server_impl.h
@@ -141,6 +141,9 @@ class PatchSubsetServerImpl : public PatchSubsetServer {
   void LoadInputCodepoints(const patch_subset::cbor::PatchRequest& request,
                            RequestState* state) const;
 
+  bool RequiredFieldsPresent(const patch_subset::cbor::PatchRequest& request,
+                             const RequestState& state) const;
+
   void CheckOriginalChecksum(uint64_t original_checksum,
                              RequestState* state) const;
 

--- a/patch_subset/server_integration_test.cc
+++ b/patch_subset/server_integration_test.cc
@@ -94,6 +94,7 @@ TEST_F(PatchSubsetServerIntegrationTest, NewRequest) {
   CompressedSet::Encode(*set_abcd, codepoints_needed);
   request.SetCodepointsNeeded(codepoints_needed);
   request.SetAcceptFormats({PatchFormat::BROTLI_SHARED_DICT});
+  request.SetProtocolVersion(ProtocolVersion::ONE);
 
   PatchResponse response;
   EXPECT_EQ(server_.Handle("Roboto-Regular.ttf", request, response),
@@ -114,6 +115,7 @@ TEST_F(PatchSubsetServerIntegrationTest, NewRequestVCDIFF) {
   CompressedSet::Encode(*set_abcd, codepoints_needed);
   request.SetCodepointsNeeded(codepoints_needed);
   request.SetAcceptFormats({PatchFormat::VCDIFF});
+  request.SetProtocolVersion(ProtocolVersion::ONE);
 
   PatchResponse response;
   EXPECT_EQ(server_.Handle("Roboto-Regular.ttf", request, response),
@@ -134,6 +136,7 @@ TEST_F(PatchSubsetServerIntegrationTest, PatchRequest) {
   patch_subset::cbor::CompressedSet codepoints_have;
   CompressedSet::Encode(*set_ab, codepoints_have);
   request.SetCodepointsHave(codepoints_have);
+  request.SetProtocolVersion(ProtocolVersion::ONE);
 
   patch_subset::cbor::CompressedSet codepoints_needed;
   CompressedSet::Encode(*set_abcd, codepoints_needed);
@@ -162,6 +165,7 @@ TEST_F(PatchSubsetServerIntegrationTest, PatchRequestVCDIFF) {
   patch_subset::cbor::CompressedSet codepoints_have;
   CompressedSet::Encode(*set_ab, codepoints_have);
   request.SetCodepointsHave(codepoints_have);
+  request.SetProtocolVersion(ProtocolVersion::ONE);
 
   patch_subset::cbor::CompressedSet codepoints_needed;
   CompressedSet::Encode(*set_abcd, codepoints_needed);
@@ -191,6 +195,7 @@ TEST_F(PatchSubsetServerIntegrationTest, BadOriginalChecksum) {
   patch_subset::cbor::CompressedSet codepoints_have;
   CompressedSet::Encode(*set_ab, codepoints_have);
   request.SetCodepointsHave(codepoints_have);
+  request.SetProtocolVersion(ProtocolVersion::ONE);
 
   patch_subset::cbor::CompressedSet codepoints_needed;
   CompressedSet::Encode(*set_abcd, codepoints_needed);
@@ -225,6 +230,7 @@ TEST_F(PatchSubsetServerIntegrationTest, BadBaseChecksum) {
   request.SetAcceptFormats({PatchFormat::BROTLI_SHARED_DICT});
   request.SetOriginalFontChecksum(original_font_checksum);
   request.SetBaseChecksum(0);
+  request.SetProtocolVersion(ProtocolVersion::ONE);
 
   PatchResponse response;
   EXPECT_EQ(server_.Handle("Roboto-Regular.ttf", request, response),


### PR DESCRIPTION
Updates the server implementation to be inline with the well formed requirements for requests in the spec.