### PR TITLE
BrotliFontDiff add support for diffing loca, hmtx, and vmtx.

### DIFF
--- a/brotli/BUILD
+++ b/brotli/BUILD
@@ -9,6 +9,7 @@ cc_library(
         "table_differ.h",
         "glyf_differ.h",
         "loca_differ.h",
+        "hmtx_differ.h",
     ],
     hdrs = [
         # TODO "shared_brotli_encoder.h",

--- a/brotli/BUILD
+++ b/brotli/BUILD
@@ -5,6 +5,7 @@ cc_library(
         "brotli_bit_buffer.cc",
         "brotli_font_diff.cc",
         "brotli_stream.cc",
+        "table_range.h",
     ],
     hdrs = [
         # TODO "shared_brotli_encoder.h",

--- a/brotli/BUILD
+++ b/brotli/BUILD
@@ -6,6 +6,9 @@ cc_library(
         "brotli_font_diff.cc",
         "brotli_stream.cc",
         "table_range.h",
+        "table_differ.h",
+        "glyf_differ.h",
+        "loca_differ.h",
     ],
     hdrs = [
         # TODO "shared_brotli_encoder.h",

--- a/brotli/BUILD
+++ b/brotli/BUILD
@@ -1,18 +1,16 @@
 cc_library(
     name = "encoding",
     srcs = [
-        # TODO "shared_brotli_encoder.cc",
         "brotli_bit_buffer.cc",
         "brotli_font_diff.cc",
         "brotli_stream.cc",
-        "table_range.h",
-        "table_differ.h",
         "glyf_differ.h",
-        "loca_differ.h",
         "hmtx_differ.h",
+        "loca_differ.h",
+        "table_differ.h",
+        "table_range.h",
     ],
     hdrs = [
-        # TODO "shared_brotli_encoder.h",
         "brotli_bit_buffer.h",
         "brotli_font_diff.h",
         "brotli_stream.h",

--- a/brotli/brotli_font_diff.cc
+++ b/brotli/brotli_font_diff.cc
@@ -3,8 +3,8 @@
 #include "absl/types/span.h"
 #include "brotli/brotli_stream.h"
 #include "brotli/glyf_differ.h"
-#include "brotli/loca_differ.h"
 #include "brotli/hmtx_differ.h"
+#include "brotli/loca_differ.h"
 #include "brotli/table_range.h"
 
 using ::absl::Span;
@@ -60,24 +60,22 @@ class DiffDriver {
         HasTable(base_face, HB_TAG('h', 'h', 'e', 'a')) &&
         HasTable(derived_face, HB_TAG('h', 'm', 't', 'x')) &&
         HasTable(derived_face, HB_TAG('h', 'h', 'e', 'a'))) {
-      differs.push_back(RangeAndDiffer(base_face, derived_face,
-                                       HB_TAG('h', 'm', 't', 'x'), stream,
-                                       new HmtxDiffer(
-                                           TableRange::to_span(base_face, HB_TAG('h', 'h', 'e', 'a')),
-                                           TableRange::to_span(derived_face,
-                                                               HB_TAG('h', 'h', 'e', 'a')))));
+      differs.push_back(RangeAndDiffer(
+          base_face, derived_face, HB_TAG('h', 'm', 't', 'x'), stream,
+          new HmtxDiffer(
+              TableRange::to_span(base_face, HB_TAG('h', 'h', 'e', 'a')),
+              TableRange::to_span(derived_face, HB_TAG('h', 'h', 'e', 'a')))));
     }
 
     if (HasTable(base_face, HB_TAG('v', 'm', 't', 'x')) &&
         HasTable(base_face, HB_TAG('v', 'h', 'e', 'a')) &&
         HasTable(derived_face, HB_TAG('v', 'm', 't', 'x')) &&
         HasTable(derived_face, HB_TAG('v', 'h', 'e', 'a'))) {
-      differs.push_back(RangeAndDiffer(base_face, derived_face,
-                                       HB_TAG('v', 'm', 't', 'x'), stream,
-                                       new HmtxDiffer(
-                                           TableRange::to_span(base_face, HB_TAG('v', 'h', 'e', 'a')),
-                                           TableRange::to_span(derived_face,
-                                                               HB_TAG('v', 'h', 'e', 'a')))));
+      differs.push_back(RangeAndDiffer(
+          base_face, derived_face, HB_TAG('v', 'm', 't', 'x'), stream,
+          new HmtxDiffer(
+              TableRange::to_span(base_face, HB_TAG('v', 'h', 'e', 'a')),
+              TableRange::to_span(derived_face, HB_TAG('v', 'h', 'e', 'a')))));
     }
 
     if (HasTable(base_face, HB_TAG('l', 'o', 'c', 'a')) &&
@@ -94,9 +92,9 @@ class DiffDriver {
     }
   }
 
-
  public:
   std::vector<RangeAndDiffer> differs;
+
  private:
   BrotliStream& out;
 
@@ -204,10 +202,10 @@ StatusCode BrotliFontDiff::Diff(
   DiffDriver diff_driver(base_plan, base_face, derived_plan, derived_face, out);
   for (auto& differ : diff_driver.differs) {
     hb_tag_t tag = differ.range.tag();
-    Span<const uint8_t> base_span = TableRange::padded_table_span(
-        TableRange::to_span(base_face, tag));
-    Span<const uint8_t> derived_span = TableRange::padded_table_span(
-      TableRange::to_span(derived_face, tag));
+    Span<const uint8_t> base_span =
+        TableRange::padded_table_span(TableRange::to_span(base_face, tag));
+    Span<const uint8_t> derived_span =
+        TableRange::padded_table_span(TableRange::to_span(derived_face, tag));
 
     unsigned base_offset = TableRange::table_offset(base_face, tag);
     unsigned derived_offset = TableRange::table_offset(derived_face, tag);

--- a/brotli/brotli_font_diff.cc
+++ b/brotli/brotli_font_diff.cc
@@ -54,15 +54,13 @@ class DiffDriver {
         base_new_to_old(hb_subset_plan_new_to_old_glyph_mapping(base_plan)),
         derived_old_to_new(
             hb_subset_plan_old_to_new_glyph_mapping(derived_plan)) {
-
     hb_blob_t* head =
         hb_face_reference_table(derived_face, HB_TAG('h', 'e', 'a', 'd'));
     const char* head_data = hb_blob_get_data(head, nullptr);
     unsigned is_derived_short_loca = !head_data[51];
     hb_blob_destroy(head);
 
-    head =
-        hb_face_reference_table(base_face, HB_TAG('h', 'e', 'a', 'd'));
+    head = hb_face_reference_table(base_face, HB_TAG('h', 'e', 'a', 'd'));
     head_data = hb_blob_get_data(head, nullptr);
     unsigned is_base_short_loca = !head_data[51];
     hb_blob_destroy(head);
@@ -105,10 +103,9 @@ class DiffDriver {
         case LOCA:
           if (HasTable(base_face, derived_face, GLYF) &&
               HasTable(base_face, derived_face, LOCA)) {
-            differs.push_back(RangeAndDiffer(base_face, derived_face, LOCA,
-                                             stream,
-                                             new LocaDiffer(is_base_short_loca,
-                                                            is_derived_short_loca)));
+            differs.push_back(RangeAndDiffer(
+                base_face, derived_face, LOCA, stream,
+                new LocaDiffer(is_base_short_loca, is_derived_short_loca)));
           }
           break;
 
@@ -118,8 +115,7 @@ class DiffDriver {
             differs.push_back(RangeAndDiffer(
                 base_face, derived_face, GLYF, stream,
                 new GlyfDiffer(TableRange::to_span(derived_face, LOCA),
-                               is_base_short_loca,
-                               is_derived_short_loca)));
+                               is_base_short_loca, is_derived_short_loca)));
           }
           break;
       }

--- a/brotli/brotli_font_diff.cc
+++ b/brotli/brotli_font_diff.cc
@@ -157,7 +157,6 @@ class DiffDriver {
   }
 
  private:
-
   unsigned BaseToDerivedGid(unsigned gid) {
     if (retain_gids) {
       // If retain gids is set gids are equivalent in all three spaces.
@@ -176,11 +175,9 @@ class DiffDriver {
   }
 };
 
-StatusCode BrotliFontDiff::Diff(
-    hb_subset_plan_t* base_plan, hb_blob_t* base,
-    hb_subset_plan_t* derived_plan, hb_blob_t* derived,
-    FontData* patch) const {
-
+StatusCode BrotliFontDiff::Diff(hb_subset_plan_t* base_plan, hb_blob_t* base,
+                                hb_subset_plan_t* derived_plan,
+                                hb_blob_t* derived, FontData* patch) const {
   Span<const uint8_t> base_span = TableRange::to_span(base);
   Span<const uint8_t> derived_span = TableRange::to_span(derived);
 
@@ -188,8 +185,9 @@ StatusCode BrotliFontDiff::Diff(
   hb_face_t* derived_face = hb_face_create(derived, 0);
   hb_face_t* base_face = hb_face_create(base, 0);
 
-  BrotliStream out(BrotliStream::WindowBitsFor(base_span.size(), derived_span.size()),
-                   base_span.size());
+  BrotliStream out(
+      BrotliStream::WindowBitsFor(base_span.size(), derived_span.size()),
+      base_span.size());
 
   unsigned derived_start_offset = 0;
   unsigned derived_end_offset = 0;

--- a/brotli/brotli_font_diff.cc
+++ b/brotli/brotli_font_diff.cc
@@ -118,6 +118,7 @@ class DiffDriver {
             differs.push_back(RangeAndDiffer(
                 base_face, derived_face, GLYF, stream,
                 new GlyfDiffer(TableRange::to_span(derived_face, LOCA),
+                               is_base_short_loca,
                                is_derived_short_loca)));
           }
           break;

--- a/brotli/brotli_font_diff.cc
+++ b/brotli/brotli_font_diff.cc
@@ -24,8 +24,6 @@ namespace brotli {
  * shared dictionary.
  */
 class DiffDriver {
-  // TODO(garretrieger): move this too it's own file.
-
   struct RangeAndDiffer {
     RangeAndDiffer(hb_face_t* base_face, hb_face_t* derived_face, hb_tag_t tag,
                    const BrotliStream& base_stream, TableDiffer* differ_)
@@ -54,8 +52,7 @@ class DiffDriver {
     retain_gids = base_glyph_count < hb_map_get_population(base_new_to_old);
 
     // TODO(garretrieger): add these from a set of tags and in the order of the
-    // tables
-    //                     in the actual font.
+    //                     tables in the actual font.
     if (HasTable(base_face, HB_TAG('h', 'm', 't', 'x')) &&
         HasTable(base_face, HB_TAG('h', 'h', 'e', 'a')) &&
         HasTable(derived_face, HB_TAG('h', 'm', 't', 'x')) &&
@@ -160,6 +157,7 @@ class DiffDriver {
   }
 
  private:
+
   unsigned BaseToDerivedGid(unsigned gid) {
     if (retain_gids) {
       // If retain gids is set gids are equivalent in all three spaces.
@@ -181,8 +179,8 @@ class DiffDriver {
 StatusCode BrotliFontDiff::Diff(
     hb_subset_plan_t* base_plan, hb_blob_t* base,
     hb_subset_plan_t* derived_plan, hb_blob_t* derived,
-    FontData* patch) const  // TODO(garretrieger): write into sink.
-{
+    FontData* patch) const {
+
   Span<const uint8_t> base_span = TableRange::to_span(base);
   Span<const uint8_t> derived_span = TableRange::to_span(derived);
 
@@ -190,9 +188,8 @@ StatusCode BrotliFontDiff::Diff(
   hb_face_t* derived_face = hb_face_create(derived, 0);
   hb_face_t* base_face = hb_face_create(base, 0);
 
-  // TODO(garretrieger): Compute a window size based on the non-glyf + base data
-  // sizes.
-  BrotliStream out(22, base_span.size());
+  BrotliStream out(BrotliStream::WindowBitsFor(base_span.size(), derived_span.size()),
+                   base_span.size());
 
   unsigned derived_start_offset = 0;
   unsigned derived_end_offset = 0;

--- a/brotli/brotli_font_diff.cc
+++ b/brotli/brotli_font_diff.cc
@@ -54,10 +54,17 @@ class DiffDriver {
         base_new_to_old(hb_subset_plan_new_to_old_glyph_mapping(base_plan)),
         derived_old_to_new(
             hb_subset_plan_old_to_new_glyph_mapping(derived_plan)) {
+
     hb_blob_t* head =
         hb_face_reference_table(derived_face, HB_TAG('h', 'e', 'a', 'd'));
     const char* head_data = hb_blob_get_data(head, nullptr);
-    unsigned use_short_loca = !head_data[51];
+    unsigned is_derived_short_loca = !head_data[51];
+    hb_blob_destroy(head);
+
+    head =
+        hb_face_reference_table(base_face, HB_TAG('h', 'e', 'a', 'd'));
+    head_data = hb_blob_get_data(head, nullptr);
+    unsigned is_base_short_loca = !head_data[51];
     hb_blob_destroy(head);
 
     base_glyph_count = hb_face_get_glyph_count(base_face);
@@ -100,7 +107,8 @@ class DiffDriver {
               HasTable(base_face, derived_face, LOCA)) {
             differs.push_back(RangeAndDiffer(base_face, derived_face, LOCA,
                                              stream,
-                                             new LocaDiffer(use_short_loca)));
+                                             new LocaDiffer(is_base_short_loca,
+                                                            is_derived_short_loca)));
           }
           break;
 
@@ -110,7 +118,7 @@ class DiffDriver {
             differs.push_back(RangeAndDiffer(
                 base_face, derived_face, GLYF, stream,
                 new GlyfDiffer(TableRange::to_span(derived_face, LOCA),
-                               use_short_loca)));
+                               is_derived_short_loca)));
           }
           break;
       }

--- a/brotli/brotli_font_diff.h
+++ b/brotli/brotli_font_diff.h
@@ -4,6 +4,7 @@
 #include "common/status.h"
 #include "hb-subset.h"
 #include "patch_subset/font_data.h"
+#include "patch_subset/hb_set_unique_ptr.h"
 
 namespace brotli {
 
@@ -13,7 +14,17 @@ namespace brotli {
  */
 class BrotliFontDiff {
  public:
-  BrotliFontDiff() {}
+  // Sorts the tables in face_builder into the order expected by the font
+  // differ.
+  static void SortForDiff(const hb_set_t* immutable_tables,
+                          const hb_set_t* custom_diff_tables,
+                          const hb_face_t* original_face,
+                          hb_face_t* face_builder /* IN/OUT */);
+
+  BrotliFontDiff(const hb_set_t* immutable_tables,
+                 const hb_set_t* custom_diff_tables)
+      : immutable_tables_(hb_set_copy(immutable_tables), &hb_set_destroy),
+        custom_diff_tables_(hb_set_copy(custom_diff_tables), &hb_set_destroy) {}
 
   patch_subset::StatusCode Diff(hb_subset_plan_t* base_plan, hb_blob_t* base,
                                 hb_subset_plan_t* derived_plan,
@@ -21,6 +32,8 @@ class BrotliFontDiff {
                                 patch_subset::FontData* patch) const;
 
  private:
+  patch_subset::hb_set_unique_ptr immutable_tables_;
+  patch_subset::hb_set_unique_ptr custom_diff_tables_;
 };
 
 }  // namespace brotli

--- a/brotli/brotli_font_diff_test.cc
+++ b/brotli/brotli_font_diff_test.cc
@@ -62,8 +62,8 @@ class BrotliFontDiffTest : public ::testing::Test {
     hb_tag_t table_tags[50];
     hb_face_get_table_tags(face, 0, &count, table_tags);
     for (unsigned i = 0; i < 50; i++) {
-      if (table_tags[i] == HB_TAG('g', 'l', 'y', 'f')
-          || table_tags[i] == HB_TAG('l', 'o', 'c', 'a'))
+      if (table_tags[i] == HB_TAG('g', 'l', 'y', 'f') ||
+          table_tags[i] == HB_TAG('l', 'o', 'c', 'a'))
         continue;
       table_order.push_back(table_tags[i]);
     }
@@ -99,8 +99,9 @@ TEST_F(BrotliFontDiffTest, Diff) {
 
   BrotliFontDiff differ;
   FontData patch;
-  ASSERT_EQ(differ.Diff(base_plan, base_blob, derived_plan, derived_blob, &patch),
-            StatusCode::kOk);
+  ASSERT_EQ(
+      differ.Diff(base_plan, base_blob, derived_plan, derived_blob, &patch),
+      StatusCode::kOk);
 
   Check(base, patch, derived);
 
@@ -133,8 +134,9 @@ TEST_F(BrotliFontDiffTest, DiffRetainGids) {
 
   BrotliFontDiff differ;
   FontData patch;
-  ASSERT_EQ(differ.Diff(base_plan, base_blob, derived_plan, derived_blob, &patch),
-            StatusCode::kOk);
+  ASSERT_EQ(
+      differ.Diff(base_plan, base_blob, derived_plan, derived_blob, &patch),
+      StatusCode::kOk);
 
   Check(base, patch, derived);
 
@@ -171,9 +173,9 @@ TEST_F(BrotliFontDiffTest, LongLoca) {
 
   BrotliFontDiff differ;
   FontData patch;
-  ASSERT_EQ(differ.Diff(base_plan, base_blob, derived_plan, derived_blob, &patch),
-            StatusCode::kOk);
-
+  ASSERT_EQ(
+      differ.Diff(base_plan, base_blob, derived_plan, derived_blob, &patch),
+      StatusCode::kOk);
 
   Check(base, patch, derived);
 

--- a/brotli/brotli_font_diff_test.cc
+++ b/brotli/brotli_font_diff_test.cc
@@ -61,6 +61,8 @@ class BrotliFontDiffTest : public ::testing::Test {
   hb_subset_input_t* input;
 };
 
+// TODO(grieger): update tests for loca diff?
+
 TEST_F(BrotliFontDiffTest, Diff) {
   hb_set_add_range(hb_subset_input_unicode_set(input), 0x41, 0x5A);
   hb_subset_plan_t* base_plan = hb_subset_plan_create_or_fail(roboto, input);

--- a/brotli/brotli_font_diff_test.cc
+++ b/brotli/brotli_font_diff_test.cc
@@ -12,6 +12,8 @@ using ::patch_subset::StatusCode;
 
 namespace brotli {
 
+const std::string kTestDataDir = "patch_subset/testdata/";
+
 /*
   for debugging:
 void dump(const char* name, const char* data, unsigned size) {
@@ -29,13 +31,13 @@ class BrotliFontDiffTest : public ::testing::Test {
 
   void SetUp() override {
     hb_blob_t* font_data = hb_blob_create_from_file_or_fail(
-        "patch_subset/testdata/Roboto-Regular.ttf");
+        (kTestDataDir + "Roboto-Regular.ttf").c_str());
     ASSERT_TRUE(font_data);
     roboto = hb_face_create(font_data, 0);
     hb_blob_destroy(font_data);
 
     font_data = hb_blob_create_from_file_or_fail(
-        "patch_subset/testdata/NotoSansJP-Regular.ttf");
+        (kTestDataDir + "NotoSansJP-Regular.ttf").c_str());
     ASSERT_TRUE(font_data);
     noto_sans_jp = hb_face_create(font_data, 0);
     hb_blob_destroy(font_data);

--- a/brotli/brotli_font_diff_test.cc
+++ b/brotli/brotli_font_diff_test.cc
@@ -61,12 +61,17 @@ class BrotliFontDiffTest : public ::testing::Test {
     unsigned count = 50;
     hb_tag_t table_tags[50];
     hb_face_get_table_tags(face, 0, &count, table_tags);
-    for (unsigned i = 0; i < 50; i++) {
+    for (unsigned i = 0; i < count; i++) {
       if (table_tags[i] == HB_TAG('g', 'l', 'y', 'f') ||
-          table_tags[i] == HB_TAG('l', 'o', 'c', 'a'))
+          table_tags[i] == HB_TAG('l', 'o', 'c', 'a') ||
+          table_tags[i] == HB_TAG('h', 'm', 't', 'x'))
+          //table_tags[i] == HB_TAG('v', 'm', 't', 'x'))
         continue;
       table_order.push_back(table_tags[i]);
     }
+
+    table_order.push_back(HB_TAG('h', 'm', 't', 'x'));
+    //table_order.push_back(HB_TAG('v', 'm', 't', 'x'));
     table_order.push_back(HB_TAG('l', 'o', 'c', 'a'));
     table_order.push_back(HB_TAG('g', 'l', 'y', 'f'));
     table_order.push_back(0);

--- a/brotli/brotli_font_diff_test.cc
+++ b/brotli/brotli_font_diff_test.cc
@@ -64,14 +64,14 @@ class BrotliFontDiffTest : public ::testing::Test {
     for (unsigned i = 0; i < count; i++) {
       if (table_tags[i] == HB_TAG('g', 'l', 'y', 'f') ||
           table_tags[i] == HB_TAG('l', 'o', 'c', 'a') ||
-          table_tags[i] == HB_TAG('h', 'm', 't', 'x'))
-          //table_tags[i] == HB_TAG('v', 'm', 't', 'x'))
+          table_tags[i] == HB_TAG('h', 'm', 't', 'x') ||
+          table_tags[i] == HB_TAG('v', 'm', 't', 'x'))
         continue;
       table_order.push_back(table_tags[i]);
     }
 
     table_order.push_back(HB_TAG('h', 'm', 't', 'x'));
-    //table_order.push_back(HB_TAG('v', 'm', 't', 'x'));
+    table_order.push_back(HB_TAG('v', 'm', 't', 'x'));
     table_order.push_back(HB_TAG('l', 'o', 'c', 'a'));
     table_order.push_back(HB_TAG('g', 'l', 'y', 'f'));
     table_order.push_back(0);

--- a/brotli/brotli_font_diff_test.cc
+++ b/brotli/brotli_font_diff_test.cc
@@ -12,12 +12,14 @@ using ::patch_subset::StatusCode;
 
 namespace brotli {
 
+/*
+  for debugging:
 void dump(const char* name, const char* data, unsigned size) {
-  // TODO remove
   FILE* f = fopen(name, "w");
   fwrite(data, size, 1, f);
   fclose(f);
 }
+*/
 
 class BrotliFontDiffTest : public ::testing::Test {
  protected:
@@ -82,8 +84,6 @@ class BrotliFontDiffTest : public ::testing::Test {
   hb_face_t* noto_sans_jp;
   hb_subset_input_t* input;
 };
-
-// TODO(grieger): update tests for loca diff?
 
 TEST_F(BrotliFontDiffTest, Diff) {
   hb_set_add_range(hb_subset_input_unicode_set(input), 0x41, 0x5A);

--- a/brotli/brotli_stream.cc
+++ b/brotli/brotli_stream.cc
@@ -128,8 +128,8 @@ bool BrotliStream::insert_from_dictionary(unsigned offset, unsigned length) {
     }
 
     return insert_from_dictionary(offset, length - remainder_length) &&
-        insert_from_dictionary(offset + (length - remainder_length),
-                               remainder_length);
+           insert_from_dictionary(offset + (length - remainder_length),
+                                  remainder_length);
   }
 
   unsigned postfix_bits = num_of_postfix_bits(distance);

--- a/brotli/brotli_stream.cc
+++ b/brotli/brotli_stream.cc
@@ -4,7 +4,6 @@
 
 #include "absl/strings/string_view.h"
 #include "brotli/shared_brotli_encoder.h"
-#include "c/enc/fast_log.h"
 #include "c/enc/prefix.h"
 #include "common/logging.h"
 

--- a/brotli/brotli_stream.h
+++ b/brotli/brotli_stream.h
@@ -15,8 +15,8 @@ namespace brotli {
  */
 class BrotliStream {
  public:
-  BrotliStream(unsigned window_bits, unsigned dictionary_size = 0)
-      : uncompressed_size_(0),
+  BrotliStream(unsigned window_bits, unsigned dictionary_size = 0, unsigned starting_offset = 0)
+      : uncompressed_size_(starting_offset),
         window_bits_(std::max(std::min(window_bits, 24u), 10u)),
         window_size_((1 << window_bits_) - 16),
         dictionary_size_(dictionary_size),
@@ -56,6 +56,10 @@ class BrotliStream {
   void end_stream();
 
   absl::Span<const uint8_t> compressed_data() const { return buffer_.data(); }
+
+  unsigned window_bits() const { return window_bits_; }
+  unsigned dictionary_size() const { return dictionary_size_; }
+  unsigned uncompressed_size() const { return uncompressed_size_; }
 
  private:
   EncoderStatePointer create_encoder(

--- a/brotli/brotli_stream.h
+++ b/brotli/brotli_stream.h
@@ -37,7 +37,9 @@ class BrotliStream {
   patch_subset::StatusCode insert_compressed_with_partial_dict(
       absl::Span<const uint8_t> bytes, absl::Span<const uint8_t> partial_dict);
 
-  // TODO test
+
+  // Appends another stream onto this one. The other stream must have been started with
+  // a starting_offset == this.uncompressed_size_.
   void append(BrotliStream& other) {
     byte_align();
     other.byte_align();
@@ -55,8 +57,8 @@ class BrotliStream {
   // Align the stream to the nearest byte boundary.
   void byte_align();
 
-  // Align the end of uncompressed data with a 4 byte boundary.
-  // TODO test
+  // Align the end of uncompressed data with a 4 byte boundary. Padding with zeroes
+  // as nescessary.
   void four_byte_align_uncompressed() {
     uint8_t zeroes[] = {0, 0, 0 ,0};
     if (uncompressed_size_ % 4 != 0) {

--- a/brotli/brotli_stream.h
+++ b/brotli/brotli_stream.h
@@ -24,6 +24,16 @@ class BrotliStream {
         dictionary_size_(dictionary_size),
         buffer_() {}
 
+  static unsigned WindowBitsFor(unsigned base_size, unsigned derived_size) {
+    for (unsigned bits = 10; bits <= 24; bits++) {
+      unsigned size = (1 << bits) - 16;
+      if (base_size + derived_size < size) {
+        return bits;
+      }
+    }
+    return 24;
+  }
+
   // Insert bytes into the uncompressed stream from the shared dictionary
   // from [offset, offset + length)
   void insert_from_dictionary(unsigned offset, unsigned length);

--- a/brotli/brotli_stream.h
+++ b/brotli/brotli_stream.h
@@ -16,7 +16,7 @@ namespace brotli {
 class BrotliStream {
  public:
   BrotliStream(unsigned window_bits, unsigned dictionary_size = 0, unsigned starting_offset = 0)
-      : uncompressed_size_(starting_offset),
+      : starting_offset_(starting_offset), uncompressed_size_(starting_offset),
         window_bits_(std::max(std::min(window_bits, 24u), 10u)),
         window_size_((1 << window_bits_) - 16),
         dictionary_size_(dictionary_size),
@@ -46,7 +46,7 @@ class BrotliStream {
     buffer_.sink().insert(buffer_.sink().end(),
                           other.buffer_.sink().begin(),
                           other.buffer_.sink().end());
-    uncompressed_size_ += other.uncompressed_size();
+    uncompressed_size_ += (other.uncompressed_size_ - other.starting_offset_);
   }
 
   // TODO(garretrieger): insert_compressed_with_partial_dict that is offset
@@ -87,6 +87,7 @@ class BrotliStream {
 
   void add_prefix_tree(unsigned code, unsigned width);
 
+  unsigned starting_offset_;
   unsigned uncompressed_size_;
   unsigned window_bits_;
   unsigned window_size_;

--- a/brotli/brotli_stream.h
+++ b/brotli/brotli_stream.h
@@ -15,8 +15,10 @@ namespace brotli {
  */
 class BrotliStream {
  public:
-  BrotliStream(unsigned window_bits, unsigned dictionary_size = 0, unsigned starting_offset = 0)
-      : starting_offset_(starting_offset), uncompressed_size_(starting_offset),
+  BrotliStream(unsigned window_bits, unsigned dictionary_size = 0,
+               unsigned starting_offset = 0)
+      : starting_offset_(starting_offset),
+        uncompressed_size_(starting_offset),
         window_bits_(std::max(std::min(window_bits, 24u), 10u)),
         window_size_((1 << window_bits_) - 16),
         dictionary_size_(dictionary_size),
@@ -37,14 +39,12 @@ class BrotliStream {
   patch_subset::StatusCode insert_compressed_with_partial_dict(
       absl::Span<const uint8_t> bytes, absl::Span<const uint8_t> partial_dict);
 
-
-  // Appends another stream onto this one. The other stream must have been started with
-  // a starting_offset == this.uncompressed_size_.
+  // Appends another stream onto this one. The other stream must have been
+  // started with a starting_offset == this.uncompressed_size_.
   void append(BrotliStream& other) {
     byte_align();
     other.byte_align();
-    buffer_.sink().insert(buffer_.sink().end(),
-                          other.buffer_.sink().begin(),
+    buffer_.sink().insert(buffer_.sink().end(), other.buffer_.sink().begin(),
                           other.buffer_.sink().end());
     uncompressed_size_ += (other.uncompressed_size_ - other.starting_offset_);
   }
@@ -57,10 +57,10 @@ class BrotliStream {
   // Align the stream to the nearest byte boundary.
   void byte_align();
 
-  // Align the end of uncompressed data with a 4 byte boundary. Padding with zeroes
-  // as nescessary.
+  // Align the end of uncompressed data with a 4 byte boundary. Padding with
+  // zeroes as nescessary.
   void four_byte_align_uncompressed() {
-    uint8_t zeroes[] = {0, 0, 0 ,0};
+    uint8_t zeroes[] = {0, 0, 0, 0};
     if (uncompressed_size_ % 4 != 0) {
       unsigned to_add = 4 - (uncompressed_size_ % 4);
       insert_uncompressed(absl::Span<const uint8_t>(zeroes, to_add));

--- a/brotli/brotli_stream.h
+++ b/brotli/brotli_stream.h
@@ -36,7 +36,7 @@ class BrotliStream {
 
   // Insert bytes into the uncompressed stream from the shared dictionary
   // from [offset, offset + length)
-  void insert_from_dictionary(unsigned offset, unsigned length);
+  [[nodiscard]] bool insert_from_dictionary(unsigned offset, unsigned length);
 
   // Insert bytes into the stream raw with no compression applied.
   void insert_uncompressed(absl::Span<const uint8_t> bytes);

--- a/brotli/brotli_stream_test.cc
+++ b/brotli/brotli_stream_test.cc
@@ -176,11 +176,8 @@ TEST_F(BrotliStreamTest, AppendStreams) {
 
   EXPECT_EQ(a.uncompressed_size(), 5 + 7 + 4);
 
-  uint8_t expected[] = {
-    'e', 'l', 'l', 'o', ' ',
-    'l', 'o', ' ', 'w', 'o', 'r', 'l',
-    ' ', 'w', 'o', 'r'
-  };
+  uint8_t expected[] = {'e', 'l', 'l', 'o', ' ', 'l', 'o', ' ',
+                        'w', 'o', 'r', 'l', ' ', 'w', 'o', 'r'};
   CheckDecompressesTo(a, expected, dict);
 }
 
@@ -199,9 +196,7 @@ TEST_F(BrotliStreamTest, FourByteAlign) {
 
   stream.end_stream();
 
-  uint8_t expected[] = {
-    '1', '2', 0, 0
-  };
+  uint8_t expected[] = {'1', '2', 0, 0};
   CheckDecompressesTo(stream, expected, dict);
 }
 

--- a/brotli/brotli_stream_test.cc
+++ b/brotli/brotli_stream_test.cc
@@ -78,6 +78,19 @@ TEST_F(BrotliStreamTest, InsertCompressedWithPartialDict) {
   CheckDecompressesTo(stream, data, dict);
 }
 
+TEST_F(BrotliStreamTest, InsertCompressedWithPartialDict_ExceedsWindow) {
+  std::vector<uint8_t> dict;
+  dict.resize(2000) ;
+
+  Span<const uint8_t> data = Span<const uint8_t>(dict).subspan(1, 10);
+
+  BrotliStream stream(10, 2000);
+  EXPECT_EQ(stream.insert_compressed_with_partial_dict(
+      data, Span<const uint8_t>(dict).subspan(0, 10)),
+            StatusCode::kInternal);
+  EXPECT_EQ(stream.uncompressed_size(), 0);
+}
+
 TEST_F(BrotliStreamTest, InsertMultipleCompressedWithPartialDict) {
   std::vector<uint8_t> dict;
   for (unsigned i = 0; i < 500; i++) {

--- a/brotli/brotli_stream_test.cc
+++ b/brotli/brotli_stream_test.cc
@@ -80,13 +80,13 @@ TEST_F(BrotliStreamTest, InsertCompressedWithPartialDict) {
 
 TEST_F(BrotliStreamTest, InsertCompressedWithPartialDict_ExceedsWindow) {
   std::vector<uint8_t> dict;
-  dict.resize(2000) ;
+  dict.resize(2000);
 
   Span<const uint8_t> data = Span<const uint8_t>(dict).subspan(1, 10);
 
   BrotliStream stream(10, 2000);
   EXPECT_EQ(stream.insert_compressed_with_partial_dict(
-      data, Span<const uint8_t>(dict).subspan(0, 10)),
+                data, Span<const uint8_t>(dict).subspan(0, 10)),
             StatusCode::kInternal);
   EXPECT_EQ(stream.uncompressed_size(), 0);
 }
@@ -161,7 +161,6 @@ TEST_F(BrotliStreamTest, InsertFromDictionarySmall) {
 }
 
 TEST_F(BrotliStreamTest, InsertFromDictionaryLarge) {
-
   std::vector<uint8_t> dict;
   dict.resize(25000000);
   dict[100] = 123;
@@ -172,13 +171,11 @@ TEST_F(BrotliStreamTest, InsertFromDictionaryLarge) {
   EXPECT_TRUE(stream.insert_from_dictionary(50, 24000000));
   stream.end_stream();
 
-  CheckDecompressesTo(stream,
-                      Span<const uint8_t>(dict).subspan(50, 24000000),
+  CheckDecompressesTo(stream, Span<const uint8_t>(dict).subspan(50, 24000000),
                       dict);
 }
 
 TEST_F(BrotliStreamTest, InsertFromDictionaryLarge_AvoidsTooSmallRef) {
-
   std::vector<uint8_t> dict;
   dict.resize(25000000);
   dict[100] = 123;
@@ -189,9 +186,8 @@ TEST_F(BrotliStreamTest, InsertFromDictionaryLarge_AvoidsTooSmallRef) {
   EXPECT_TRUE(stream.insert_from_dictionary(50, (1 << 24) + 1));
   stream.end_stream();
 
-  CheckDecompressesTo(stream,
-                      Span<const uint8_t>(dict).subspan(50, (1 << 24) + 1),
-                      dict);
+  CheckDecompressesTo(
+      stream, Span<const uint8_t>(dict).subspan(50, (1 << 24) + 1), dict);
 }
 
 TEST_F(BrotliStreamTest, InsertMixed) {

--- a/brotli/brotli_stream_test.cc
+++ b/brotli/brotli_stream_test.cc
@@ -189,7 +189,7 @@ TEST_F(BrotliStreamTest, FourByteAlign) {
   stream.four_byte_align_uncompressed();
   EXPECT_EQ(stream.uncompressed_size(), 0);
 
-  stream.insert_from_dictionary(0, 1);
+  stream.insert_from_dictionary(0, 2);
   stream.four_byte_align_uncompressed();
   EXPECT_EQ(stream.uncompressed_size(), 4);
   stream.four_byte_align_uncompressed();
@@ -198,9 +198,11 @@ TEST_F(BrotliStreamTest, FourByteAlign) {
   stream.end_stream();
 
   uint8_t expected[] = {
-    '1', 0, 0, 0
+    '1', '2', 0, 0
   };
   CheckDecompressesTo(stream, expected, dict);
 }
+
+// TODO(garretrieger): test one byte dictionary insert.
 
 }  // namespace brotli

--- a/brotli/brotli_stream_test.cc
+++ b/brotli/brotli_stream_test.cc
@@ -174,6 +174,8 @@ TEST_F(BrotliStreamTest, AppendStreams) {
   a.append(c);
   a.end_stream();
 
+  EXPECT_EQ(a.uncompressed_size(), 5 + 7 + 4);
+
   uint8_t expected[] = {
     'e', 'l', 'l', 'o', ' ',
     'l', 'o', ' ', 'w', 'o', 'r', 'l',

--- a/brotli/glyf_differ.h
+++ b/brotli/glyf_differ.h
@@ -27,7 +27,7 @@ class GlyfDiffer : public TableDiffer {
     return GlyphLength(derived_gid);
   }
 
-  unsigned Finalize() override {
+  unsigned Finalize() const override {
     // noop
     return 0;
   }

--- a/brotli/glyf_differ.h
+++ b/brotli/glyf_differ.h
@@ -19,11 +19,11 @@ class GlyfDiffer : public TableDiffer {
   bool is_derived_short_loca_;
 
  public:
-  GlyfDiffer(absl::Span<const uint8_t> loca, bool is_base_short_loca, bool is_derived_short_loca)
+  GlyfDiffer(absl::Span<const uint8_t> loca, bool is_base_short_loca,
+             bool is_derived_short_loca)
       : loca_(loca),
         is_base_short_loca_(is_base_short_loca),
-        is_derived_short_loca_(is_derived_short_loca)
-  {}
+        is_derived_short_loca_(is_derived_short_loca) {}
 
   void Process(unsigned derived_gid, unsigned base_gid,
                unsigned base_derived_gid, bool is_base_empty,
@@ -31,11 +31,12 @@ class GlyfDiffer : public TableDiffer {
                unsigned* derived_delta /* OUT */) override {
     *derived_delta = GlyphLength(derived_gid);
     if (is_base_short_loca_ != is_derived_short_loca_) {
-      // If loca's don't match then glyphs in the base may not use the same byte alignment.
-      // so we can't blindly reference them. For now just treat all glyphs as new data.
+      // If loca's don't match then glyphs in the base may not use the same byte
+      // alignment. so we can't blindly reference them. For now just treat all
+      // glyphs as new data.
       //
-      // Ideally the subsetter should ensure that a consistent loca format is used in all subsets
-      // for optimal patch performance.
+      // Ideally the subsetter should ensure that a consistent loca format is
+      // used in all subsets for optimal patch performance.
       mode = NEW_DATA;
       *base_delta = 0;
       return;

--- a/brotli/glyf_differ.h
+++ b/brotli/glyf_differ.h
@@ -7,7 +7,6 @@
 namespace brotli {
 
 class GlyfDiffer : public TableDiffer {
-
  private:
   enum Mode {
     INIT = 0,
@@ -19,12 +18,10 @@ class GlyfDiffer : public TableDiffer {
   bool use_short_loca_;
 
  public:
-  GlyfDiffer(absl::Span<const uint8_t> loca, bool use_short_loca) :
-      loca_(loca), use_short_loca_(use_short_loca)
-  {}
+  GlyfDiffer(absl::Span<const uint8_t> loca, bool use_short_loca)
+      : loca_(loca), use_short_loca_(use_short_loca) {}
 
-  unsigned Process(unsigned derived_gid,
-                   unsigned base_gid,
+  unsigned Process(unsigned derived_gid, unsigned base_gid,
                    unsigned base_derived_gid) override {
     mode = (base_derived_gid == derived_gid) ? EXISTING_DATA : NEW_DATA;
     return GlyphLength(derived_gid);
@@ -35,9 +32,7 @@ class GlyfDiffer : public TableDiffer {
     return 0;
   }
 
-  bool IsNewData() const override {
-    return mode == NEW_DATA;
-  }
+  bool IsNewData() const override { return mode == NEW_DATA; }
 
  private:
   // Length of glyph (in bytes) found in the derived subset.

--- a/brotli/glyf_differ.h
+++ b/brotli/glyf_differ.h
@@ -1,0 +1,79 @@
+#ifndef BROTLI_GLYF_DIFFER_H_
+#define BROTLI_GLYF_DIFFER_H_
+
+#include "absl/types/span.h"
+#include "brotli/table_differ.h"
+
+namespace brotli {
+
+class GlyfDiffer : public TableDiffer {
+
+ private:
+  enum Mode {
+    INIT = 0,
+    NEW_DATA,
+    EXISTING_DATA,
+  } mode = INIT;
+
+  absl::Span<const uint8_t> loca_;
+  bool use_short_loca_;
+
+ public:
+  GlyfDiffer(absl::Span<const uint8_t> loca, bool use_short_loca) :
+      loca_(loca), use_short_loca_(use_short_loca)
+  {}
+
+  unsigned Process(unsigned derived_gid,
+                   unsigned base_gid,
+                   unsigned base_derived_gid) override {
+    mode = (base_derived_gid == derived_gid) ? EXISTING_DATA : NEW_DATA;
+    return GlyphLength(derived_gid);
+  }
+
+  unsigned Finalize() override {
+    // noop
+    return 0;
+  }
+
+  bool IsNewData() const override {
+    return mode == NEW_DATA;
+  }
+
+ private:
+  // Length of glyph (in bytes) found in the derived subset.
+  unsigned GlyphLength(unsigned gid) {
+    const uint8_t* derived_loca = loca_.data();
+
+    if (use_short_loca_) {
+      unsigned index = gid * 2;
+
+      unsigned off_1 = ((derived_loca[index] & 0xFF) << 8) |
+                       (derived_loca[index + 1] & 0xFF);
+
+      index += 2;
+      unsigned off_2 = ((derived_loca[index] & 0xFF) << 8) |
+                       (derived_loca[index + 1] & 0xFF);
+
+      return (off_2 * 2) - (off_1 * 2);
+    }
+
+    unsigned index = gid * 4;
+
+    unsigned off_1 = ((derived_loca[index] & 0xFF) << 24) |
+                     ((derived_loca[index + 1] & 0xFF) << 16) |
+                     ((derived_loca[index + 2] & 0xFF) << 8) |
+                     (derived_loca[index + 3] & 0xFF);
+
+    index += 4;
+    unsigned off_2 = ((derived_loca[index] & 0xFF) << 24) |
+                     ((derived_loca[index + 1] & 0xFF) << 16) |
+                     ((derived_loca[index + 2] & 0xFF) << 8) |
+                     (derived_loca[index + 3] & 0xFF);
+
+    return off_2 - off_1;
+  }
+};
+
+}  // namespace brotli
+
+#endif  // BROTLI_GLYF_DIFFER_H_

--- a/brotli/hmtx_differ.h
+++ b/brotli/hmtx_differ.h
@@ -7,14 +7,12 @@
 namespace brotli {
 
 class HmtxDiffer : public TableDiffer {
-
  private:
   enum Mode {
     INIT = 0,
     NEW_DATA,
     EXISTING_DATA,
   } mode = INIT;
-
 
   unsigned base_number_of_metrics;
   unsigned derived_number_of_metrics;
@@ -25,16 +23,14 @@ class HmtxDiffer : public TableDiffer {
       : base_number_of_metrics(GetNumberOfMetrics(base_hhea)),
         derived_number_of_metrics(GetNumberOfMetrics(derived_hhea)) {}
 
-  unsigned Process(unsigned derived_gid,
-                   unsigned base_gid,
+  unsigned Process(unsigned derived_gid, unsigned base_gid,
                    unsigned base_derived_gid) override {
-
     mode = NEW_DATA;
     if (derived_gid == base_derived_gid) {
-      if ((derived_gid < derived_number_of_metrics
-           && base_gid < base_number_of_metrics) ||
-          (derived_gid >= derived_number_of_metrics
-           && base_gid >= base_number_of_metrics)) {
+      if ((derived_gid < derived_number_of_metrics &&
+           base_gid < base_number_of_metrics) ||
+          (derived_gid >= derived_number_of_metrics &&
+           base_gid >= base_number_of_metrics)) {
         // Can only copy existing data if both base and derived are on the same
         // side of number of metrics.
         mode = EXISTING_DATA;
@@ -49,9 +45,7 @@ class HmtxDiffer : public TableDiffer {
     return 0;
   }
 
-  bool IsNewData() const override {
-    return mode == NEW_DATA;
-  }
+  bool IsNewData() const override { return mode == NEW_DATA; }
 
  private:
   static unsigned GetNumberOfMetrics(absl::Span<const uint8_t> hhea) {

--- a/brotli/hmtx_differ.h
+++ b/brotli/hmtx_differ.h
@@ -1,0 +1,71 @@
+#ifndef BROTLI_HMTX_DIFFER_H_
+#define BROTLI_HMTX_DIFFER_H_
+
+#include "absl/types/span.h"
+#include "brotli/table_differ.h"
+
+namespace brotli {
+
+class HmtxDiffer : public TableDiffer {
+
+ private:
+  enum Mode {
+    INIT = 0,
+    NEW_DATA,
+    EXISTING_DATA,
+  } mode = INIT;
+
+
+  unsigned base_number_of_metrics;
+  unsigned derived_number_of_metrics;
+
+ public:
+  HmtxDiffer(absl::Span<const uint8_t> base_hhea,
+             absl::Span<const uint8_t> derived_hhea)
+      : base_number_of_metrics(GetNumberOfMetrics(base_hhea)),
+        derived_number_of_metrics(GetNumberOfMetrics(derived_hhea)) {}
+
+  unsigned Process(unsigned derived_gid,
+                   unsigned base_gid,
+                   unsigned base_derived_gid) override {
+
+    mode = NEW_DATA;
+    if (derived_gid == base_derived_gid) {
+      if ((derived_gid < derived_number_of_metrics
+           && base_gid < base_number_of_metrics) ||
+          (derived_gid >= derived_number_of_metrics
+           && base_gid >= base_number_of_metrics)) {
+        // Can only copy existing data if both base and derived are on the same
+        // side of number of metrics.
+        mode = EXISTING_DATA;
+      }
+    }
+
+    return derived_gid < derived_number_of_metrics ? 4 : 2;
+  }
+
+  unsigned Finalize() const override {
+    // noop
+    return 0;
+  }
+
+  bool IsNewData() const override {
+    return mode == NEW_DATA;
+  }
+
+ private:
+  static unsigned GetNumberOfMetrics(absl::Span<const uint8_t> hhea) {
+    constexpr unsigned field_offset = 34;
+
+    if (hhea.size() < field_offset + 2) {
+      return 0;
+    }
+
+    const uint8_t* num_metrics = hhea.data() + field_offset;
+    return (num_metrics[0] << 8) | num_metrics[1];
+  }
+};
+
+}  // namespace brotli
+
+#endif  // BROTLI_HMTX_DIFFER_H_

--- a/brotli/loca_differ.h
+++ b/brotli/loca_differ.h
@@ -34,7 +34,7 @@ class LocaDiffer : public TableDiffer {
     return loca_width_;
   }
 
-  unsigned Finalize() override {
+  unsigned Finalize() const override {
     // Loca table has one extra entry at the end. Stay in current mode.
     return loca_width_;
   }

--- a/brotli/loca_differ.h
+++ b/brotli/loca_differ.h
@@ -7,7 +7,6 @@
 namespace brotli {
 
 class LocaDiffer : public TableDiffer {
-
  private:
   enum Mode {
     INIT = 0,
@@ -18,11 +17,9 @@ class LocaDiffer : public TableDiffer {
   unsigned loca_width_;
 
  public:
-  LocaDiffer(bool is_short_loca) : loca_width_(is_short_loca ? 2 : 4)
-  {}
+  LocaDiffer(bool is_short_loca) : loca_width_(is_short_loca ? 2 : 4) {}
 
-  unsigned Process(unsigned derived_gid,
-                   unsigned base_gid,
+  unsigned Process(unsigned derived_gid, unsigned base_gid,
                    unsigned base_derived_gid) override {
     switch (mode) {
       case INIT:
@@ -30,8 +27,8 @@ class LocaDiffer : public TableDiffer {
         mode = (base_derived_gid == derived_gid) ? EXISTING_DATA : NEW_DATA;
         break;
       case NEW_DATA:
-        // Once new data is encountered all remaining data must be new since loca
-        // entries depend on previous loca entries.
+        // Once new data is encountered all remaining data must be new since
+        // loca entries depend on previous loca entries.
         break;
     }
     return loca_width_;
@@ -42,9 +39,7 @@ class LocaDiffer : public TableDiffer {
     return loca_width_;
   }
 
-  bool IsNewData() const override {
-    return mode == NEW_DATA;
-  }
+  bool IsNewData() const override { return mode == NEW_DATA; }
 
  private:
 };

--- a/brotli/loca_differ.h
+++ b/brotli/loca_differ.h
@@ -20,8 +20,7 @@ class LocaDiffer : public TableDiffer {
  public:
   // TODO(garretrieger): we need to check if both base and derived are short
   // loca. if they don't match than all entries are new.
-  LocaDiffer(bool is_base_short_loca,
-             bool is_derived_short_loca)
+  LocaDiffer(bool is_base_short_loca, bool is_derived_short_loca)
       : mismatched_loca_format_(is_base_short_loca != is_derived_short_loca),
         loca_width_(is_derived_short_loca ? 2 : 4) {}
 
@@ -31,8 +30,8 @@ class LocaDiffer : public TableDiffer {
                unsigned* derived_delta /* OUT */) override {
     *derived_delta = loca_width_;
     if (mismatched_loca_format_) {
-      // If loca format is not the same between base and derived then we can't re-use
-      // any data from the base loca.
+      // If loca format is not the same between base and derived then we can't
+      // re-use any data from the base loca.
       mode = NEW_DATA;
     }
 

--- a/brotli/loca_differ.h
+++ b/brotli/loca_differ.h
@@ -17,26 +17,40 @@ class LocaDiffer : public TableDiffer {
   unsigned loca_width_;
 
  public:
+  // TODO(garretrieger): we need to check if both base and derived are short
+  // loca. if they don't match than all entries are new.
   LocaDiffer(bool is_short_loca) : loca_width_(is_short_loca ? 2 : 4) {}
 
-  unsigned Process(unsigned derived_gid, unsigned base_gid,
-                   unsigned base_derived_gid) override {
+  void Process(unsigned derived_gid, unsigned base_gid,
+               unsigned base_derived_gid, bool is_base_empty,
+               unsigned* base_delta, /* OUT */
+               unsigned* derived_delta /* OUT */) override {
+    *derived_delta = loca_width_;
     switch (mode) {
       case INIT:
       case EXISTING_DATA:
-        mode = (base_derived_gid == derived_gid) ? EXISTING_DATA : NEW_DATA;
-        break;
+        if (base_derived_gid == derived_gid) {
+          mode = EXISTING_DATA;
+          *base_delta = loca_width_;
+          break;
+        }
+
+        mode = NEW_DATA;
+        // fallthrough
       case NEW_DATA:
+
         // Once new data is encountered all remaining data must be new since
         // loca entries depend on previous loca entries.
+        *base_delta = 0;
         break;
     }
-    return loca_width_;
   }
 
-  unsigned Finalize() const override {
+  void Finalize(unsigned* base_delta, /* OUT */
+                unsigned* derived_delta /* OUT */) const override {
     // Loca table has one extra entry at the end. Stay in current mode.
-    return loca_width_;
+    *base_delta = loca_width_;
+    *derived_delta = loca_width_;
   }
 
   bool IsNewData() const override { return mode == NEW_DATA; }

--- a/brotli/loca_differ.h
+++ b/brotli/loca_differ.h
@@ -1,0 +1,54 @@
+#ifndef BROTLI_LOCA_DIFFER_H_
+#define BROTLI_LOCA_DIFFER_H_
+
+#include "absl/types/span.h"
+#include "brotli/table_differ.h"
+
+namespace brotli {
+
+class LocaDiffer : public TableDiffer {
+
+ private:
+  enum Mode {
+    INIT = 0,
+    NEW_DATA,
+    EXISTING_DATA,
+  } mode = INIT;
+
+  unsigned loca_width_;
+
+ public:
+  LocaDiffer(bool is_short_loca) : loca_width_(is_short_loca ? 2 : 4)
+  {}
+
+  unsigned Process(unsigned derived_gid,
+                   unsigned base_gid,
+                   unsigned base_derived_gid) override {
+    switch (mode) {
+      case INIT:
+      case EXISTING_DATA:
+        mode = (base_derived_gid == derived_gid) ? EXISTING_DATA : NEW_DATA;
+        break;
+      case NEW_DATA:
+        // Once new data is encountered all remaining data must be new since loca
+        // entries depend on previous loca entries.
+        break;
+    }
+    return loca_width_;
+  }
+
+  unsigned Finalize() override {
+    // Loca table has one extra entry at the end. Stay in current mode.
+    return loca_width_;
+  }
+
+  bool IsNewData() const override {
+    return mode == NEW_DATA;
+  }
+
+ private:
+};
+
+}  // namespace brotli
+
+#endif  // BROTLI_LOCA_DIFFER_H_

--- a/brotli/table_differ.h
+++ b/brotli/table_differ.h
@@ -10,8 +10,7 @@ class TableDiffer {
  public:
   virtual ~TableDiffer() = default;
 
-  virtual unsigned Process(unsigned derived_gid,
-                           unsigned base_gid,
+  virtual unsigned Process(unsigned derived_gid, unsigned base_gid,
                            unsigned base_derived_gid) = 0;
 
   virtual unsigned Finalize() = 0;

--- a/brotli/table_differ.h
+++ b/brotli/table_differ.h
@@ -10,10 +10,13 @@ class TableDiffer {
  public:
   virtual ~TableDiffer() = default;
 
-  virtual unsigned Process(unsigned derived_gid, unsigned base_gid,
-                           unsigned base_derived_gid) = 0;
+  virtual void Process(unsigned derived_gid, unsigned base_gid,
+                       unsigned base_derived_gid, bool is_base_empty,
+                       unsigned* base_delta, /* OUT */
+                       unsigned* derived_delta /* OUT */) = 0;
 
-  virtual unsigned Finalize() const = 0;
+  virtual void Finalize(unsigned* base_delta, /* OUT */
+                        unsigned* derived_delta /* OUT */) const = 0;
 
   virtual bool IsNewData() const = 0;
 };

--- a/brotli/table_differ.h
+++ b/brotli/table_differ.h
@@ -1,0 +1,24 @@
+#ifndef BROTLI_TABLE_DIFFER_H_
+#define BROTLI_TABLE_DIFFER_H_
+
+namespace brotli {
+
+/*
+ * A helper class used to generate a brotli compressed stream.
+ */
+class TableDiffer {
+ public:
+  virtual ~TableDiffer() = default;
+
+  virtual unsigned Process(unsigned derived_gid,
+                           unsigned base_gid,
+                           unsigned base_derived_gid) = 0;
+
+  virtual unsigned Finalize() = 0;
+
+  virtual bool IsNewData() const = 0;
+};
+
+}  // namespace brotli
+
+#endif  // BROTLI_TABLE_DIFFER_H_

--- a/brotli/table_differ.h
+++ b/brotli/table_differ.h
@@ -13,7 +13,7 @@ class TableDiffer {
   virtual unsigned Process(unsigned derived_gid, unsigned base_gid,
                            unsigned base_derived_gid) = 0;
 
-  virtual unsigned Finalize() = 0;
+  virtual unsigned Finalize() const = 0;
 
   virtual bool IsNewData() const = 0;
 };

--- a/brotli/table_range.h
+++ b/brotli/table_range.h
@@ -86,7 +86,11 @@ class TableRange {
   }
 
   void CommitExisting() {
-    out->insert_from_dictionary(base_table_offset_ + base_offset_, length_);
+    if (!out->insert_from_dictionary(base_table_offset_ + base_offset_, length_)) {
+      // 1 byte backwards refs must be inserted as literals.
+      out->insert_uncompressed(
+          absl::Span<const uint8_t>(derived_.data() + derived_offset_, length_));
+    }
     base_offset_ += length_;
     derived_offset_ += length_;
     length_ = 0;

--- a/brotli/table_range.h
+++ b/brotli/table_range.h
@@ -6,13 +6,12 @@
 namespace brotli {
 
 class TableRange {
-
  public:
   static absl::Span<const uint8_t> to_span(hb_face_t* face, hb_tag_t tag) {
     hb_blob_t* table = hb_face_reference_table(face, tag);
     absl::Span<const uint8_t> result = to_span(table);
     hb_blob_destroy(table);
-    
+
     return result;
   }
 
@@ -20,11 +19,12 @@ class TableRange {
     unsigned length;
     const uint8_t* data =
         reinterpret_cast<const uint8_t*>(hb_blob_get_data(table, &length));
-    
+
     return absl::Span<const uint8_t>(data, length);
   }
 
-  static absl::Span<const uint8_t> padded_table_span(absl::Span<const uint8_t> span) {
+  static absl::Span<const uint8_t> padded_table_span(
+      absl::Span<const uint8_t> span) {
     unsigned new_size = span.size();
     while (new_size % 4) {
       new_size++;
@@ -35,7 +35,8 @@ class TableRange {
   static unsigned table_offset(hb_face_t* face, hb_tag_t tag) {
     hb_blob_t* table = hb_face_reference_table(face, tag);
     hb_blob_t* blob = hb_face_reference_blob(face);
-    unsigned offset = hb_blob_get_data(table, nullptr) - hb_blob_get_data(blob, nullptr);
+    unsigned offset =
+        hb_blob_get_data(table, nullptr) - hb_blob_get_data(blob, nullptr);
 
     hb_blob_destroy(table);
     hb_blob_destroy(blob);
@@ -44,13 +45,10 @@ class TableRange {
   }
 
  public:
-  TableRange(hb_face_t* base_face,
-             hb_face_t* derived_face,
-             hb_tag_t tag,
-             const BrotliStream& base_stream)
-  {
+  TableRange(hb_face_t* base_face, hb_face_t* derived_face, hb_tag_t tag,
+             const BrotliStream& base_stream) {
     derived_ = to_span(derived_face, tag);
-    
+
     out.reset(new BrotliStream(base_stream.window_bits(),
                                base_stream.dictionary_size(),
                                table_offset(derived_face, tag)));
@@ -68,20 +66,13 @@ class TableRange {
   std::unique_ptr<BrotliStream> out;
 
  public:
+  BrotliStream& stream() { return *out; }
 
-  BrotliStream& stream() {
-    return *out;
-  }
-  
   const uint8_t* data() { return derived_.data(); }
-  
-  unsigned length() {
-    return derived_.size();
-  }
 
-  void Extend(unsigned length) {
-    length_ += length;
-  }
+  unsigned length() { return derived_.size(); }
+
+  void Extend(unsigned length) { length_ += length; }
 
   void CommitNew() {
     out->insert_compressed(

--- a/brotli/table_range.h
+++ b/brotli/table_range.h
@@ -1,0 +1,103 @@
+#ifndef BROTLI_TABLE_RANGE_H_
+#define BROTLI_TABLE_RANGE_H_
+
+#include "absl/types/span.h"
+
+namespace brotli {
+
+class TableRange {
+
+ public:
+  static absl::Span<const uint8_t> to_span(hb_face_t* face, hb_tag_t tag) {
+    hb_blob_t* table = hb_face_reference_table(face, tag);
+    absl::Span<const uint8_t> result = to_span(table);
+    hb_blob_destroy(table);
+    
+    return result;
+  }
+
+  static absl::Span<const uint8_t> to_span(hb_blob_t* table) {
+    unsigned length;
+    const uint8_t* data =
+        reinterpret_cast<const uint8_t*>(hb_blob_get_data(table, &length));
+    
+    return absl::Span<const uint8_t>(data, length);
+  }
+
+  static absl::Span<const uint8_t> padded_table_span(absl::Span<const uint8_t> span) {
+    unsigned new_size = span.size();
+    while (new_size % 4) {
+      new_size++;
+    }
+    return absl::Span<const uint8_t>(span.data(), new_size);
+  }
+
+  static unsigned table_offset(hb_face_t* face, hb_tag_t tag) {
+    hb_blob_t* table = hb_face_reference_table(face, tag);
+    hb_blob_t* blob = hb_face_reference_blob(face);
+    unsigned offset = hb_blob_get_data(table, nullptr) - hb_blob_get_data(blob, nullptr);
+
+    hb_blob_destroy(table);
+    hb_blob_destroy(blob);
+
+    return offset;
+  }
+
+ public:
+  TableRange(hb_face_t* base_face,
+             hb_face_t* derived_face,
+             hb_tag_t tag,
+             const BrotliStream& base_stream)
+  {
+    derived_ = to_span(derived_face, tag);
+    
+    out.reset(new BrotliStream(base_stream.window_bits(),
+                               base_stream.dictionary_size(),
+                               table_offset(derived_face, tag)));
+
+    base_table_offset_ = table_offset(base_face, tag);
+  }
+
+ private:
+  absl::Span<const uint8_t> derived_;
+
+  unsigned base_table_offset_;
+  unsigned base_offset_ = 0;
+  unsigned derived_offset_ = 0;
+  unsigned length_ = 0;
+  std::unique_ptr<BrotliStream> out;
+
+ public:
+
+  BrotliStream& stream() {
+    return *out;
+  }
+  
+  const uint8_t* data() { return derived_.data(); }
+  
+  unsigned length() {
+    return derived_.size();
+  }
+
+  void Extend(unsigned length) {
+    length_ += length;
+  }
+
+  void CommitNew() {
+    out->insert_compressed(
+        absl::Span<const uint8_t>(derived_.data() + derived_offset_, length_));
+    derived_offset_ += length_;
+    length_ = 0;
+  }
+
+  void CommitExisting() {
+    out->insert_from_dictionary(base_table_offset_ + base_offset_, length_);
+    base_offset_ += length_;
+    derived_offset_ += length_;
+    length_ = 0;
+  }
+};
+
+}  // namespace brotli
+
+#endif  // BROTLI_TABLE_RANGE_H_

--- a/brotli/table_range.h
+++ b/brotli/table_range.h
@@ -68,7 +68,6 @@ class TableRange {
   hb_tag_t tag_;
 
  public:
-
   hb_tag_t tag() const { return tag_; }
 
   BrotliStream& stream() { return *out; }

--- a/brotli/table_range.h
+++ b/brotli/table_range.h
@@ -86,10 +86,11 @@ class TableRange {
   }
 
   void CommitExisting() {
-    if (!out->insert_from_dictionary(base_table_offset_ + base_offset_, length_)) {
+    if (!out->insert_from_dictionary(base_table_offset_ + base_offset_,
+                                     length_)) {
       // 1 byte backwards refs must be inserted as literals.
-      out->insert_uncompressed(
-          absl::Span<const uint8_t>(derived_.data() + derived_offset_, length_));
+      out->insert_uncompressed(absl::Span<const uint8_t>(
+          derived_.data() + derived_offset_, length_));
     }
     base_offset_ += length_;
     derived_offset_ += length_;

--- a/brotli/table_range.h
+++ b/brotli/table_range.h
@@ -54,6 +54,7 @@ class TableRange {
                                table_offset(derived_face, tag)));
 
     base_table_offset_ = table_offset(base_face, tag);
+    tag_ = tag;
   }
 
  private:
@@ -64,8 +65,12 @@ class TableRange {
   unsigned derived_offset_ = 0;
   unsigned length_ = 0;
   std::unique_ptr<BrotliStream> out;
+  hb_tag_t tag_;
 
  public:
+
+  hb_tag_t tag() const { return tag_; }
+
   BrotliStream& stream() { return *out; }
 
   const uint8_t* data() { return derived_.data(); }

--- a/brotli/table_range.h
+++ b/brotli/table_range.h
@@ -2,6 +2,8 @@
 #define BROTLI_TABLE_RANGE_H_
 
 #include "absl/types/span.h"
+#include "brotli/brotli_stream.h"
+#include "hb-subset.h"
 
 namespace brotli {
 

--- a/patch_subset/bit_output_buffer.cc
+++ b/patch_subset/bit_output_buffer.cc
@@ -71,7 +71,7 @@ std::string BitOutputBuffer::to_string() {
 }
 
 static uint8_t EncodeFirstByte(BranchFactor branch_factor, unsigned int depth) {
-  uint8_t result;
+  uint8_t result = 0;
   switch (branch_factor) {
     case BF2:
       result = 0b00;

--- a/patch_subset/sparse_bit_set.cc
+++ b/patch_subset/sparse_bit_set.cc
@@ -170,7 +170,7 @@ uint32_t EstimateTreeSize(uint32_t num_leaf_nodes, BranchFactor branch_factor) {
   //
   // The ratios below were chosen to match the tree sizes seen in a combination
   // of uniform random and codepoint-usage-frequency weighted random sets.
-  double geometric_sum;
+  double geometric_sum = 1.0;
   switch (branch_factor) {
     case BF2:
       // Estimate that the number of nodes divides by 1.4 going up each level.

--- a/util/precompress-test.cc
+++ b/util/precompress-test.cc
@@ -22,7 +22,7 @@ using patch_subset::BrotliBinaryPatch;
 using patch_subset::FontData;
 using patch_subset::StatusCode;
 
-constexpr bool DUMP_STATE = true;
+constexpr bool DUMP_STATE = false;
 constexpr unsigned STATIC_QUALITY = 11;
 // Number of codepoints to include in the subset. Set to
 // -1 to use ascii as a subset.
@@ -255,11 +255,13 @@ class Operation {
       for (unsigned i = 0; i < count; i++) {
         if (table_tags[i] == HB_TAG('g', 'l', 'y', 'f') ||
             table_tags[i] == HB_TAG('l', 'o', 'c', 'a') ||
-            table_tags[i] == HB_TAG('h', 'm', 't', 'x'))
+            table_tags[i] == HB_TAG('h', 'm', 't', 'x') ||
+            table_tags[i] == HB_TAG('v', 'm', 't', 'x'))
           continue;
         table_order.push_back(table_tags[i]);
       }
       table_order.push_back(HB_TAG('h', 'm', 't', 'x'));
+      table_order.push_back(HB_TAG('v', 'm', 't', 'x'));
       table_order.push_back(HB_TAG('l', 'o', 'c', 'a'));
       table_order.push_back(HB_TAG('g', 'l', 'y', 'f'));
       table_order.push_back(0);

--- a/util/precompress-test.cc
+++ b/util/precompress-test.cc
@@ -22,13 +22,13 @@ using patch_subset::BrotliBinaryPatch;
 using patch_subset::FontData;
 using patch_subset::StatusCode;
 
-constexpr bool DUMP_STATE = true;
+constexpr bool DUMP_STATE = false;
 constexpr unsigned STATIC_QUALITY = 11;
 // Number of codepoints to include in the subset. Set to
 // -1 to use ascii as a subset.
 constexpr unsigned SUBSET_COUNT = 10;
 constexpr unsigned BASE_COUNT = 1000;
-constexpr unsigned TRIAL_DURATION_MS = 5000;
+constexpr unsigned TRIAL_DURATION_MS = 1000;
 
 // TODO(grieger): this should be all "No Subset Tables" in the font.
 hb_tag_t immutable_tables[] = {
@@ -250,8 +250,8 @@ class Operation {
       hb_tag_t table_tags[50];
       hb_face_get_table_tags(face, 0, &count, table_tags);
       for (unsigned i = 0; i < 50; i++) {
-        if (table_tags[i] == HB_TAG('g', 'l', 'y', 'f')
-            || table_tags[i] == HB_TAG('l', 'o', 'c', 'a'))
+        if (table_tags[i] == HB_TAG('g', 'l', 'y', 'f') ||
+            table_tags[i] == HB_TAG('l', 'o', 'c', 'a'))
           continue;
         table_order.push_back(table_tags[i]);
       }
@@ -482,7 +482,7 @@ int main(int argc, char** argv) {
 
   hb_face_t* face = hb_face_create(font_blob, 0);
 
-  //test_precompression(face);
+  // test_precompression(face);
   test_dictionary_size(face);
 
   hb_blob_destroy(font_blob);


### PR DESCRIPTION
Update the custom diffing mechanism to take an list of differs, one per table. Each per table differ is a state machine that instructs the diff driver how to construct the ranges of bytes that are existing and new data. Currently differs are implemented for glyf, loca, hmtx, and vmtx.