### PR TITLE
Add additional set method for fontdata that allows both face and blob…

### DIFF
--- a/patch_subset/font_data.h
+++ b/patch_subset/font_data.h
@@ -111,6 +111,13 @@ class FontData {
     hb_blob_destroy(blob);
   }
 
+  void set(hb_face_t* face, hb_blob_t* blob) {
+    reset();
+
+    saved_face_ = hb_face_reference(face);
+    buffer_ = hb_blob_reference(blob);
+  }
+
   void shallow_copy(const FontData& other) {
     if (other.saved_face_) {
       set(other.saved_face_);


### PR DESCRIPTION
… to be provided.

Useful when using preprocessed faces, as referencing the blob from the face causes it to be recomputed.