### PR TITLE
Use 'sbr' instead of 'brdiff' for content encoding.

### DIFF
--- a/js_client/patch_subset_client.cc
+++ b/js_client/patch_subset_client.cc
@@ -179,7 +179,7 @@ class State {
     attr.requestData = payload->data();
     attr.requestDataSize = payload->size();
 
-    const char* headers[] = {"Accept-Encoding", "brdiff", NULL};
+    const char* headers[] = {"Accept-Encoding", "br, sbr", NULL};
     attr.requestHeaders = headers;
 
     RequestContext* context = new RequestContext(callback, std::move(payload));

--- a/js_client/patch_subset_client.cc
+++ b/js_client/patch_subset_client.cc
@@ -95,8 +95,11 @@ void RequestSucceeded(emscripten_fetch_t* fetch) {
 
     auto encoding = GetContentEncoding(fetch);
     if (encoding.ok()) {
+      // 'br' encoding will have already been decoded by the browser, so switch
+      // to 'identity'.
+      std::string encoding_str = (*encoding == "br") ? "identity" : *encoding;
       auto result = context->client->DecodeResponse(*(context->subset),
-                                                    response, *encoding);
+                                                    response, encoding_str);
       if (result.ok()) {
         context->subset->shallow_copy(*result);
       } else {

--- a/patch_subset/encodings.h
+++ b/patch_subset/encodings.h
@@ -6,7 +6,8 @@ namespace patch_subset {
 namespace Encodings {
 
 static const char* kIdentityEncoding [[maybe_unused]] = "identity";
-static const char* kBrotliDiffEncoding [[maybe_unused]] = "brdiff";
+static const char* kBrotliDiffEncoding [[maybe_unused]] = "sbr";
+static const char* kBrotliEncoding [[maybe_unused]] = "br";
 static const char* kVCDIFFEncoding [[maybe_unused]] = "vcdiff";
 
 }  // namespace Encodings

--- a/patch_subset/patch_subset_client_test.cc
+++ b/patch_subset/patch_subset_client_test.cc
@@ -262,7 +262,7 @@ TEST_F(PatchSubsetClientTest, DecodeResponse) {
   FontData patch("roboto.patch.ttf");
   ExpectPatch(base, patch, "roboto.patched.ttf");
 
-  auto result = client_->DecodeResponse(base, patch, "brdiff");
+  auto result = client_->DecodeResponse(base, patch, "sbr");
   ASSERT_TRUE(result.ok()) << result.status();
 
   EXPECT_EQ(result->str(), "roboto.patched.ttf");

--- a/patch_subset/patch_subset_server_impl.cc
+++ b/patch_subset/patch_subset_server_impl.cc
@@ -100,7 +100,8 @@ Status PatchSubsetServerImpl::Handle(
 
   ValidatePatchBase(request.BaseChecksum(), &state);
 
-  const BinaryDiff* binary_diff = DiffFor(accept_encoding, state.IsPatch(), state.encoding);
+  const BinaryDiff* binary_diff =
+      DiffFor(accept_encoding, state.IsPatch(), state.encoding);
   if (!binary_diff) {
     return absl::InvalidArgumentError(
         "No available binary diff algorithms were specified.");
@@ -354,12 +355,11 @@ Status PatchSubsetServerImpl::CreateClientState(
 }
 
 const BinaryDiff* PatchSubsetServerImpl::DiffFor(
-    const std::vector<std::string>& accept_encoding,
-    bool is_patch,
+    const std::vector<std::string>& accept_encoding, bool is_patch,
     std::string& encoding /* OUT */) const {
-  if (!is_patch
-      && std::find(accept_encoding.begin(), accept_encoding.end(),
-                   Encodings::kBrotliEncoding) != accept_encoding.end()) {
+  if (!is_patch &&
+      std::find(accept_encoding.begin(), accept_encoding.end(),
+                Encodings::kBrotliEncoding) != accept_encoding.end()) {
     // Brotli is preferred and this is not a patch, so just use regular brotli.
     encoding = Encodings::kBrotliEncoding;
     return brotli_binary_diff_.get();

--- a/patch_subset/patch_subset_server_impl.h
+++ b/patch_subset/patch_subset_server_impl.h
@@ -175,6 +175,7 @@ class PatchSubsetServerImpl : public PatchSubsetServer {
                            patch_subset::cbor::ClientState& client_state) const;
 
   const BinaryDiff* DiffFor(const std::vector<std::string>& accept_encoding,
+                            bool is_patch,
                             std::string& encoding /* OUT */) const;
 
   int max_predicted_codepoints_;

--- a/patch_subset/patch_subset_server_impl_test.cc
+++ b/patch_subset/patch_subset_server_impl_test.cc
@@ -199,15 +199,13 @@ TEST_F(PatchSubsetServerImplTest, NewRequest_NoSharedBrotli) {
   CompressedSet::Encode(*set_abcd_, codepoints_needed);
   request.SetCodepointsNeeded(codepoints_needed);
 
-  EXPECT_EQ(
-      server_.Handle("Roboto-Regular.ttf", {Encodings::kBrotliEncoding},
-                     request, response, encoding),
-      absl::OkStatus());
+  EXPECT_EQ(server_.Handle("Roboto-Regular.ttf", {Encodings::kBrotliEncoding},
+                           request, response, encoding),
+            absl::OkStatus());
 
   EXPECT_EQ(response.str(), "Roboto-Regular.ttf:abcd, {orig_cs=42}");
   EXPECT_EQ(encoding, Encodings::kBrotliEncoding);
 }
-
 
 TEST_F(PatchSubsetServerImplTest, NewRequestVCDIFF) {
   ExpectRoboto();

--- a/patch_subset/patch_subset_server_impl_test.cc
+++ b/patch_subset/patch_subset_server_impl_test.cc
@@ -185,6 +185,30 @@ TEST_F(PatchSubsetServerImplTest, NewRequest) {
   EXPECT_EQ(encoding, Encodings::kBrotliDiffEncoding);
 }
 
+TEST_F(PatchSubsetServerImplTest, NewRequest_NoSharedBrotli) {
+  ExpectRoboto();
+  ExpectBrotliDiff();
+
+  ExpectChecksum("Roboto-Regular.ttf", 42);
+  ExpectChecksum("Roboto-Regular.ttf:abcd", 43);
+
+  PatchRequest request;
+  FontData response;
+  std::string encoding;
+  patch_subset::cbor::CompressedSet codepoints_needed;
+  CompressedSet::Encode(*set_abcd_, codepoints_needed);
+  request.SetCodepointsNeeded(codepoints_needed);
+
+  EXPECT_EQ(
+      server_.Handle("Roboto-Regular.ttf", {Encodings::kBrotliEncoding},
+                     request, response, encoding),
+      absl::OkStatus());
+
+  EXPECT_EQ(response.str(), "Roboto-Regular.ttf:abcd, {orig_cs=42}");
+  EXPECT_EQ(encoding, Encodings::kBrotliEncoding);
+}
+
+
 TEST_F(PatchSubsetServerImplTest, NewRequestVCDIFF) {
   ExpectRoboto();
   ExpectVCDIFF();


### PR DESCRIPTION
This matches the proposed shared brotli content encoding value in https://github.com/WICG/compression-dictionary-transport