### PR TITLE
Implement support for mixed shared brotli and IFTB patches in the same font.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -56,9 +56,9 @@ http_archive(
 http_archive(
     name = "harfbuzz",
     build_file = "//third_party:harfbuzz.BUILD",
-    sha256 = "032c712d82d38ec6d3677b349f93acd12c6ed19bbdfcd116a356b73ce8ef6588",
-    strip_prefix = "harfbuzz-f26fd69d858642d76413b8f4068eaf9b57c40a5f",
-    urls = ["https://github.com/harfbuzz/harfbuzz/archive/f26fd69d858642d76413b8f4068eaf9b57c40a5f.zip"],
+    strip_prefix = "harfbuzz-559d225aafa3832e7394d68a3c717968ad367845",
+    sha256 = "f2bb1da8f28f6cfff3172b4599e654fb777ad04d93b610404200a96a3a13146a",
+    urls = ["https://github.com/harfbuzz/harfbuzz/archive/559d225aafa3832e7394d68a3c717968ad367845.zip"],
 )
 
 # Fast Hash

--- a/common/BUILD
+++ b/common/BUILD
@@ -10,8 +10,10 @@ cc_library(
   deps = [
     "@harfbuzz",
     "@com_google_absl//absl/container:flat_hash_set",
+    "@com_google_absl//absl/container:flat_hash_map",
     "@com_google_absl//absl/status:statusor",
     "@com_google_absl//absl/strings",
+    "//patch_subset:common",
   ]
 )
 
@@ -26,6 +28,6 @@ cc_test(
   ],
   deps = [
     ":common",
-    "@gtest//:gtest_main",
+    "@gtest//:gtest_main",    
   ],
 )

--- a/common/font_helper.cc
+++ b/common/font_helper.cc
@@ -1,4 +1,5 @@
 #include "common/font_helper.h"
+
 #include <cstdint>
 
 #include "absl/container/flat_hash_map.h"
@@ -8,7 +9,7 @@ using absl::flat_hash_map;
 namespace common {
 
 flat_hash_map<uint32_t, uint32_t> FontHelper::GidToUnicodeMap(hb_face_t* face) {
-  hb_map_t* unicode_to_gid = hb_map_create ();
+  hb_map_t* unicode_to_gid = hb_map_create();
   hb_face_collect_nominal_glyph_mapping(face, unicode_to_gid, nullptr);
 
   flat_hash_map<uint32_t, uint32_t> gid_to_unicode;

--- a/common/font_helper.cc
+++ b/common/font_helper.cc
@@ -2,8 +2,8 @@
 
 namespace common {
 
-absl::flat_hash_set<uint32_t> FontHelper::GetTags(hb_face_t* face) {
-  absl::flat_hash_set<uint32_t> tag_set;
+absl::flat_hash_set<hb_tag_t> FontHelper::GetTags(hb_face_t* face) {
+  absl::flat_hash_set<hb_tag_t> tag_set;
   constexpr uint32_t max_tags = 64;
   hb_tag_t table_tags[max_tags];
   unsigned table_count = max_tags;
@@ -31,14 +31,19 @@ std::vector<hb_tag_t> FontHelper::GetOrderedTags(hb_face_t* face) {
   return ordered_tags;
 }
 
+std::string FontHelper::ToString(hb_tag_t tag) {
+  std::string tag_name;
+  tag_name.resize(5);  // need 5 for the null terminator
+  snprintf(tag_name.data(), 5, "%c%c%c%c", HB_UNTAG(tag));
+  tag_name.resize(4);
+  return tag_name;
+}
+
 std::vector<std::string> FontHelper::ToStrings(
     const std::vector<hb_tag_t>& tags) {
   std::vector<std::string> result;
   for (hb_tag_t tag : tags) {
-    std::string tag_name;
-    tag_name.resize(4);
-    sprintf(tag_name.data(), "%c%c%c%c", HB_UNTAG(tag));
-    result.push_back(tag_name);
+    result.push_back(ToString(tag));
   }
 
   return result;

--- a/common/font_helper.cc
+++ b/common/font_helper.cc
@@ -1,6 +1,27 @@
 #include "common/font_helper.h"
+#include <cstdint>
+
+#include "absl/container/flat_hash_map.h"
+
+using absl::flat_hash_map;
 
 namespace common {
+
+flat_hash_map<uint32_t, uint32_t> FontHelper::GidToUnicodeMap(hb_face_t* face) {
+  hb_map_t* unicode_to_gid = hb_map_create ();
+  hb_face_collect_nominal_glyph_mapping(face, unicode_to_gid, nullptr);
+
+  flat_hash_map<uint32_t, uint32_t> gid_to_unicode;
+  int index = -1;
+  uint32_t cp = HB_MAP_VALUE_INVALID;
+  uint32_t gid = HB_MAP_VALUE_INVALID;
+  while (hb_map_next(unicode_to_gid, &index, &cp, &gid)) {
+    gid_to_unicode[gid] = cp;
+  }
+
+  hb_map_destroy(unicode_to_gid);
+  return gid_to_unicode;
+}
 
 absl::flat_hash_set<hb_tag_t> FontHelper::GetTags(hb_face_t* face) {
   absl::flat_hash_set<hb_tag_t> tag_set;

--- a/common/font_helper.cc
+++ b/common/font_helper.cc
@@ -53,6 +53,26 @@ std::vector<hb_tag_t> FontHelper::GetOrderedTags(hb_face_t* face) {
   return ordered_tags;
 }
 
+void FontHelper::ApplyIftbTableOrdering(hb_face_t* subset) {
+  std::vector<hb_tag_t> tags = GetOrderedTags(subset);
+  std::vector<hb_tag_t> new_order;
+  for (hb_tag_t t : tags) {
+    if (t != FontHelper::kGlyf && t != FontHelper::kLoca &&
+        t != FontHelper::kCFF && t != FontHelper::kCFF2 &&
+        t != FontHelper::kGvar) {
+      new_order.push_back(t);
+    }
+  }
+
+  new_order.push_back(FontHelper::kCFF);
+  new_order.push_back(FontHelper::kCFF2);
+  new_order.push_back(FontHelper::kGvar);
+  new_order.push_back(FontHelper::kGlyf);
+  new_order.push_back(FontHelper::kLoca);
+  new_order.push_back(0);
+  hb_face_builder_sort_tables(subset, new_order.data());
+}
+
 std::string FontHelper::ToString(hb_tag_t tag) {
   std::string tag_name;
   tag_name.resize(5);  // need 5 for the null terminator

--- a/common/font_helper.h
+++ b/common/font_helper.h
@@ -39,7 +39,9 @@ class FontHelper {
   constexpr static hb_tag_t kIFTB = HB_TAG('I', 'F', 'T', 'B');
   constexpr static hb_tag_t kLoca = HB_TAG('l', 'o', 'c', 'a');
   constexpr static hb_tag_t kGlyf = HB_TAG('g', 'l', 'y', 'f');
+  constexpr static hb_tag_t kGvar = HB_TAG('g', 'v', 'a', 'r');
   constexpr static hb_tag_t kCFF = HB_TAG('C', 'F', 'F', ' ');
+  constexpr static hb_tag_t kCFF2 = HB_TAG('C', 'F', 'F', '2');
 
   static absl::StatusOr<uint32_t> ReadUInt32(absl::string_view value) {
     if (value.size() < 4) {
@@ -102,6 +104,7 @@ class FontHelper {
       hb_face_t* face);
   static absl::flat_hash_set<hb_tag_t> GetTags(hb_face_t* face);
   static std::vector<hb_tag_t> GetOrderedTags(hb_face_t* face);
+  static void ApplyIftbTableOrdering(hb_face_t* face);
   static std::vector<std::string> ToStrings(const std::vector<hb_tag_t>& input);
   static std::string ToString(hb_tag_t tag);
 };

--- a/common/font_helper.h
+++ b/common/font_helper.h
@@ -55,7 +55,7 @@ class FontHelper {
       return absl::InvalidArgumentError("Need at least 2 bytes");
     }
     const uint8_t* bytes = (const uint8_t*)value.data();
-    return (((uint16_t)bytes[0]) << 8) + (((uint16_t)bytes[1])); 
+    return (((uint16_t)bytes[0]) << 8) + (((uint16_t)bytes[1]));
   }
 
   static absl::StatusOr<absl::string_view> Loca(hb_face_t* face) {
@@ -98,7 +98,8 @@ class FontHelper {
     return result;
   }
 
-  static absl::flat_hash_map<uint32_t, uint32_t> GidToUnicodeMap(hb_face_t* face);
+  static absl::flat_hash_map<uint32_t, uint32_t> GidToUnicodeMap(
+      hb_face_t* face);
   static absl::flat_hash_set<hb_tag_t> GetTags(hb_face_t* face);
   static std::vector<hb_tag_t> GetOrderedTags(hb_face_t* face);
   static std::vector<std::string> ToStrings(const std::vector<hb_tag_t>& input);

--- a/common/font_helper.h
+++ b/common/font_helper.h
@@ -50,6 +50,14 @@ class FontHelper {
            (((uint32_t)bytes[2]) << 8) + ((uint32_t)bytes[3]);
   }
 
+  static absl::StatusOr<uint16_t> ReadUInt16(absl::string_view value) {
+    if (value.size() < 2) {
+      return absl::InvalidArgumentError("Need at least 2 bytes");
+    }
+    const uint8_t* bytes = (const uint8_t*)value.data();
+    return (((uint16_t)bytes[0]) << 8) + (((uint16_t)bytes[1])); 
+  }
+
   static absl::StatusOr<absl::string_view> Loca(hb_face_t* face) {
     hb_blob_t* loca_blob = hb_face_reference_table(face, FontHelper::kLoca);
     uint32_t loca_length = 0;

--- a/common/font_helper.h
+++ b/common/font_helper.h
@@ -98,6 +98,7 @@ class FontHelper {
     return result;
   }
 
+  static absl::flat_hash_map<uint32_t, uint32_t> GidToUnicodeMap(hb_face_t* face);
   static absl::flat_hash_set<hb_tag_t> GetTags(hb_face_t* face);
   static std::vector<hb_tag_t> GetOrderedTags(hb_face_t* face);
   static std::vector<std::string> ToStrings(const std::vector<hb_tag_t>& input);

--- a/common/font_helper_test.cc
+++ b/common/font_helper_test.cc
@@ -1,11 +1,12 @@
 #include "common/font_helper.h"
+
 #include <cstdint>
 
 #include "absl/container/flat_hash_map.h"
 #include "gtest/gtest.h"
 
-using absl::string_view;
 using absl::flat_hash_map;
+using absl::string_view;
 
 namespace common {
 
@@ -77,8 +78,8 @@ TEST_F(FontHelperTest, GidToUnicodeMap) {
   auto map = FontHelper::GidToUnicodeMap(roboto_ab);
 
   absl::flat_hash_map<uint32_t, uint32_t> expected = {
-    {69, 0x61},
-    {70, 0x62},
+      {69, 0x61},
+      {70, 0x62},
   };
 
   ASSERT_EQ(map, expected);

--- a/common/font_helper_test.cc
+++ b/common/font_helper_test.cc
@@ -75,4 +75,26 @@ TEST_F(FontHelperTest, GetOrderedTags) {
   EXPECT_EQ(s[17], "fpgm");
 }
 
+TEST_F(FontHelperTest, ToString) {
+  ASSERT_EQ("glyf", FontHelper::ToString(HB_TAG('g', 'l', 'y', 'f')));
+  ASSERT_EQ("abCD", FontHelper::ToString(HB_TAG('a', 'b', 'C', 'D')));
+}
+
+TEST_F(FontHelperTest, BuildFont) {
+  absl::flat_hash_map<hb_tag_t, std::string> tables = {
+      {HB_TAG('a', 'b', 'c', 'd'), "table_1"},
+      {HB_TAG('d', 'e', 'f', 'g'), "table_2"},
+  };
+  auto font = FontHelper::BuildFont(tables);
+
+  hb_face_t* face = font.reference_face();
+  auto table_1 = FontHelper::TableData(face, HB_TAG('a', 'b', 'c', 'd'));
+  auto table_2 = FontHelper::TableData(face, HB_TAG('d', 'e', 'f', 'g'));
+
+  ASSERT_EQ(table_1.str(), "table_1");
+  ASSERT_EQ(table_2.str(), "table_2");
+}
+
+// TODO test BuildFont...
+
 }  // namespace common

--- a/common/font_helper_test.cc
+++ b/common/font_helper_test.cc
@@ -26,6 +26,21 @@ class FontHelperTest : public ::testing::Test {
   hb_face_t* roboto_ab;
 };
 
+TEST_F(FontHelperTest, ReadUInt16) {
+  uint8_t input1[] = {0x12, 0x34, 0x56, 0x78};
+  auto s = FontHelper::ReadUInt16(string_view((const char*)input1, 4));
+  ASSERT_TRUE(s.ok()) << s.status();
+  ASSERT_EQ(*s, 0x1234);
+
+  uint8_t input2[] = {0x00, 0xFA};
+  s = FontHelper::ReadUInt16(string_view((const char*)input2, 2));
+  ASSERT_TRUE(s.ok()) << s.status();
+  ASSERT_EQ(*s, 0x00FA);
+
+  s = FontHelper::ReadUInt16(string_view((const char*)input1, 1));
+  ASSERT_FALSE(s.ok());
+}
+
 TEST_F(FontHelperTest, ReadUInt32) {
   uint8_t input1[] = {0x12, 0x34, 0x56, 0x78};
   auto s = FontHelper::ReadUInt32(string_view((const char*)input1, 4));

--- a/common/font_helper_test.cc
+++ b/common/font_helper_test.cc
@@ -1,8 +1,11 @@
 #include "common/font_helper.h"
+#include <cstdint>
 
+#include "absl/container/flat_hash_map.h"
 #include "gtest/gtest.h"
 
 using absl::string_view;
+using absl::flat_hash_map;
 
 namespace common {
 
@@ -68,6 +71,17 @@ TEST_F(FontHelperTest, Loca) {
 
   s = FontHelper::Loca(noto_sans_jp_otf);
   ASSERT_TRUE(absl::IsNotFound(s.status())) << s.status();
+}
+
+TEST_F(FontHelperTest, GidToUnicodeMap) {
+  auto map = FontHelper::GidToUnicodeMap(roboto_ab);
+
+  absl::flat_hash_map<uint32_t, uint32_t> expected = {
+    {69, 0x61},
+    {70, 0x62},
+  };
+
+  ASSERT_EQ(map, expected);
 }
 
 TEST_F(FontHelperTest, GetTags) {

--- a/ift/BUILD
+++ b/ift/BUILD
@@ -3,10 +3,13 @@ cc_library(
     srcs = [
         "ift_client.cc",
         "iftb_binary_patch.h",
-        "iftb_binary_patch.cc",        
+        "iftb_binary_patch.cc",
+        "per_table_brotli_binary_diff.h",
+        "per_table_brotli_binary_diff.cc",
     ],
     hdrs = [
         "ift_client.h",
+        "per_table_brotli_binary_diff.h",
     ],
     visibility = [
         "//visibility:public",
@@ -35,6 +38,7 @@ cc_test(
     srcs = [
         "ift_client_test.cc",
         "iftb_binary_patch_test.cc",
+        "per_table_brotli_binary_diff_test.cc",
     ],
     data = [
         "//patch_subset:testdata",

--- a/ift/BUILD
+++ b/ift/BUILD
@@ -3,7 +3,7 @@ cc_library(
     srcs = [
         "ift_client.cc",
         "iftb_binary_patch.h",
-        "iftb_binary_patch.cc",
+        "iftb_binary_patch.cc",        
     ],
     hdrs = [
         "ift_client.h",

--- a/ift/BUILD
+++ b/ift/BUILD
@@ -43,7 +43,10 @@ cc_test(
         "iftb_binary_patch_test.cc",
         "per_table_brotli_binary_diff_test.cc",
         "per_table_brotli_binary_patch_test.cc",
-        # TODO "integration_test.cc",
+        "integration_test.cc",
+    ],
+    copts = [
+        "-DHB_EXPERIMENTAL_API",
     ],
     data = [
         "//patch_subset:testdata",

--- a/ift/BUILD
+++ b/ift/BUILD
@@ -43,6 +43,7 @@ cc_test(
         "iftb_binary_patch_test.cc",
         "per_table_brotli_binary_diff_test.cc",
         "per_table_brotli_binary_patch_test.cc",
+        "integration_test.cc",
     ],
     data = [
         "//patch_subset:testdata",
@@ -53,6 +54,7 @@ cc_test(
         "//patch_subset:server",
         "//ift/proto:proto",
         "//ift/proto:IFT_cc_proto",
+        "//ift/encoder",
         "@com_google_absl//absl/container:btree",
         "@gtest//:gtest_main",
     ],

--- a/ift/BUILD
+++ b/ift/BUILD
@@ -43,7 +43,7 @@ cc_test(
         "iftb_binary_patch_test.cc",
         "per_table_brotli_binary_diff_test.cc",
         "per_table_brotli_binary_patch_test.cc",
-        "integration_test.cc",
+        # TODO "integration_test.cc",
     ],
     data = [
         "//patch_subset:testdata",

--- a/ift/BUILD
+++ b/ift/BUILD
@@ -6,10 +6,13 @@ cc_library(
         "iftb_binary_patch.cc",
         "per_table_brotli_binary_diff.h",
         "per_table_brotli_binary_diff.cc",
+        "per_table_brotli_binary_patch.h",
+        "per_table_brotli_binary_patch.cc",
     ],
     hdrs = [
         "ift_client.h",
         "per_table_brotli_binary_diff.h",
+        "per_table_brotli_binary_patch.h",
     ],
     visibility = [
         "//visibility:public",
@@ -39,6 +42,7 @@ cc_test(
         "ift_client_test.cc",
         "iftb_binary_patch_test.cc",
         "per_table_brotli_binary_diff_test.cc",
+        "per_table_brotli_binary_patch_test.cc",
     ],
     data = [
         "//patch_subset:testdata",

--- a/ift/BUILD
+++ b/ift/BUILD
@@ -30,7 +30,7 @@ cc_library(
 )
 
 cc_test(
-    name = "ift_client_test",
+    name = "client_test",
     size = "small",
     srcs = [
         "ift_client_test.cc",

--- a/ift/encoder/BUILD
+++ b/ift/encoder/BUILD
@@ -17,6 +17,9 @@ cc_library(
     "@harfbuzz",
     "@woff2",
   ],
+  copts = [
+    "-DHB_EXPERIMENTAL_API",
+  ],
   visibility = [
     "//util:__pkg__",
     "//ift:__pkg__",

--- a/ift/encoder/BUILD
+++ b/ift/encoder/BUILD
@@ -19,6 +19,7 @@ cc_library(
   ],
   visibility = [
     "//util:__pkg__",
+    "//ift:__pkg__",
     "//js_client:__pkg__",
   ],
 )

--- a/ift/encoder/BUILD
+++ b/ift/encoder/BUILD
@@ -8,6 +8,7 @@ cc_library(
     "//patch_subset:common",
     "//ift/proto:IFT_cc_proto",
     "//ift/proto",
+    "//ift:client",
     "@com_google_absl//absl/container:flat_hash_map",
     "@com_google_absl//absl/container:flat_hash_set",
     "@com_google_absl//absl/container:btree",
@@ -36,5 +37,6 @@ cc_test(
     ":encoder",
     "//patch_subset:client",
      "@gtest//:gtest_main",
+     "//common",
   ],
 )

--- a/ift/encoder/encoder.cc
+++ b/ift/encoder/encoder.cc
@@ -200,7 +200,8 @@ StatusOr<FontData> Encoder::DecodeWoff2(string_view font) {
   return result;
 }
 
-StatusOr<FontData> Encoder::RoundTripWoff2(string_view font, bool glyf_transform) {
+StatusOr<FontData> Encoder::RoundTripWoff2(string_view font,
+                                           bool glyf_transform) {
   auto r = EncodeWoff2(font, glyf_transform);
   if (!r.ok()) {
     return r.status();

--- a/ift/encoder/encoder.cc
+++ b/ift/encoder/encoder.cc
@@ -173,6 +173,11 @@ StatusOr<FontData> Encoder::CutSubset(
     hb_set_add(unicodes, cp);
   }
 
+  if (IsMixedMode()) {
+    // Mixed mode requires stable gids, so set retain gids.
+    hb_subset_input_set_flags(input, HB_SUBSET_FLAGS_RETAIN_GIDS);
+  }
+
   hb_face_t* result = hb_subset_or_fail(font, input);
   hb_blob_t* blob = hb_face_reference_blob(result);
 

--- a/ift/encoder/encoder.cc
+++ b/ift/encoder/encoder.cc
@@ -94,6 +94,7 @@ Status Encoder::AddExistingIftbPatch(uint32_t id, const FontData& patch) {
   }
 
   existing_iftb_patches_[id] = subset;
+  next_id_ = std::max(next_id_, id + 1);
   return absl::OkStatus();
 }
 

--- a/ift/encoder/encoder.cc
+++ b/ift/encoder/encoder.cc
@@ -336,11 +336,14 @@ StatusOr<FontData> Encoder::CutSubset(hb_face_t* font,
   if (IsMixedMode()) {
     // Mixed mode requires stable gids and IFTB requirements to be met,
     // set flags accordingly.
-    hb_subset_input_set_flags(input, HB_SUBSET_FLAGS_RETAIN_GIDS);
-    hb_subset_input_set_flags(input, HB_SUBSET_FLAGS_IFTB_REQUIREMENTS);
+    hb_subset_input_set_flags(
+        input, HB_SUBSET_FLAGS_RETAIN_GIDS | HB_SUBSET_FLAGS_IFTB_REQUIREMENTS |
+                   HB_SUBSET_FLAGS_NOTDEF_OUTLINE |
+                   HB_SUBSET_FLAGS_PASSTHROUGH_UNRECOGNIZED);
   }
 
   hb_face_t* result = hb_subset_or_fail(font, input);
+  FontHelper::ApplyIftbTableOrdering(result);
   hb_blob_t* blob = hb_face_reference_blob(result);
 
   FontData subset(blob);

--- a/ift/encoder/encoder.h
+++ b/ift/encoder/encoder.h
@@ -51,11 +51,11 @@ class Encoder {
       bool is_root = true);
 
   static absl::StatusOr<patch_subset::FontData> EncodeWoff2(
-      absl::string_view font, bool glyf_transform=true);
+      absl::string_view font, bool glyf_transform = true);
   static absl::StatusOr<patch_subset::FontData> DecodeWoff2(
       absl::string_view font);
   static absl::StatusOr<patch_subset::FontData> RoundTripWoff2(
-      absl::string_view font, bool glyf_transform=true);
+      absl::string_view font, bool glyf_transform = true);
 
  private:
   absl::StatusOr<patch_subset::FontData> CutSubset(

--- a/ift/encoder/encoder.h
+++ b/ift/encoder/encoder.h
@@ -115,6 +115,8 @@ class Encoder {
       return H::combine(std::move(h), s.codepoints, s.gids);
     }
 
+    void Union(const SubsetDefinition& other);
+
     void ConfigureInput(hb_subset_input_t* input) const;
   };
 
@@ -137,7 +139,7 @@ class Encoder {
       const SubsetDefinition& base_subset,
       std::vector<const SubsetDefinition*> subsets, bool is_root = true);
 
-  absl::StatusOr<absl::flat_hash_set<uint32_t>> CodepointsForIftbPatches(
+  absl::StatusOr<SubsetDefinition> SubsetDefinitionForIftbPatches(
       const absl::flat_hash_set<uint32_t>& ids);
 
   bool IsMixedMode() const { return !existing_iftb_patches_.empty(); }
@@ -152,8 +154,7 @@ class Encoder {
   std::string url_template_ = "patch$5$4$3$2$1.br";
   uint32_t id_[4] = {0, 0, 0, 0};
   hb_face_t* face_ = nullptr;
-  absl::btree_map<uint32_t, absl::flat_hash_set<uint32_t>>
-      existing_iftb_patches_;
+  absl::btree_map<uint32_t, SubsetDefinition> existing_iftb_patches_;
   SubsetDefinition base_subset_;
   std::vector<SubsetDefinition> extension_subsets_;
   // TODO(garretrieger): also track additional gids that should be

--- a/ift/encoder/encoder.h
+++ b/ift/encoder/encoder.h
@@ -39,7 +39,7 @@ class Encoder {
 
   absl::Span<const uint32_t> Id() const {
     // TODO(garretrieger): generate a new id on creation.
-    const uint32_t id[4] = {1, 2, 3, 4};
+    constexpr static uint32_t id[4] = {1, 2, 3, 4};
     return id;
   }
 

--- a/ift/encoder/encoder.h
+++ b/ift/encoder/encoder.h
@@ -33,6 +33,11 @@ class Encoder {
     }
   }
 
+  Encoder(const Encoder&) = delete;
+  Encoder(Encoder&& other) = delete;
+  Encoder& operator=(const Encoder&) = delete;
+  Encoder& operator=(Encoder&& other) = delete;
+
   void SetUrlTemplate(const std::string& value) { url_template_ = value; }
 
   const std::string& UrlTemplate() const { return url_template_; }

--- a/ift/encoder/encoder.h
+++ b/ift/encoder/encoder.h
@@ -129,6 +129,9 @@ class Encoder {
       existing_iftb_patches_;
   absl::flat_hash_set<hb_codepoint_t> base_subset_;
   std::vector<absl::flat_hash_set<hb_codepoint_t>> extension_subsets_;
+  // TODO(garretrieger): also track additional gids that should be
+  //  included in a subset (coming from the IFTB patches). implement
+  //  by having a custom struct for subsets which as a gid and codepoint set.
 
   // OUT
   uint32_t next_id_ = 0;

--- a/ift/encoder/encoder.h
+++ b/ift/encoder/encoder.h
@@ -25,7 +25,7 @@ namespace ift::encoder {
 class Encoder {
  public:
   Encoder()
-      : binary_diff_(11), per_table_binary_diff_({"IFT", "glyf", "loca"}) {}
+      : binary_diff_(11), per_table_binary_diff_({"IFT ", "glyf", "loca"}) {}
 
   ~Encoder() {
     if (face_) {

--- a/ift/encoder/encoder_test.cc
+++ b/ift/encoder/encoder_test.cc
@@ -370,6 +370,7 @@ TEST_F(EncoderTest, Encode_ThreeSubsets_Mixed) {
   ASSERT_EQ(ift_table->GetPatchMap().GetEntries().size(), 3);
 
   const auto& entry0 = ift_table->GetPatchMap().GetEntries()[0];
+  ASSERT_EQ(entry0.patch_index, 3);
   ASSERT_FALSE(entry0.coverage.codepoints.contains(chunk0_cp));
   ASSERT_FALSE(entry0.coverage.codepoints.contains(chunk1_cp));
   ASSERT_FALSE(entry0.coverage.codepoints.contains(chunk2_cp));
@@ -377,6 +378,7 @@ TEST_F(EncoderTest, Encode_ThreeSubsets_Mixed) {
   ASSERT_FALSE(entry0.coverage.codepoints.contains(chunk4_cp));
 
   const auto& entry1 = ift_table->GetPatchMap().GetEntries()[1];
+  ASSERT_EQ(entry1.patch_index, 4);
   ASSERT_FALSE(entry1.coverage.codepoints.contains(chunk0_cp));
   ASSERT_FALSE(entry1.coverage.codepoints.contains(chunk1_cp));
   ASSERT_FALSE(entry1.coverage.codepoints.contains(chunk2_cp));
@@ -384,6 +386,7 @@ TEST_F(EncoderTest, Encode_ThreeSubsets_Mixed) {
   ASSERT_TRUE(entry1.coverage.codepoints.contains(chunk4_cp));
 
   const auto& entry2 = ift_table->GetPatchMap().GetEntries()[2];
+  ASSERT_EQ(entry2.patch_index, 5);
   ASSERT_FALSE(entry2.coverage.codepoints.contains(chunk0_cp));
   ASSERT_FALSE(entry2.coverage.codepoints.contains(chunk1_cp));
   ASSERT_FALSE(entry2.coverage.codepoints.contains(chunk2_cp));

--- a/ift/encoder/encoder_test.cc
+++ b/ift/encoder/encoder_test.cc
@@ -89,10 +89,11 @@ class EncoderTest : public ::testing::Test {
     }
 
     flat_hash_map<uint32_t, btree_set<uint32_t>> subsets;
-    for (const auto& p : ift_table->GetPatchMap()) {
-      uint32_t cp = p.first;
-      uint32_t id = p.second.first;
-      subsets[id].insert(cp);
+    for (const auto& e : ift_table->GetPatchMap().GetEntries()) {
+      uint32_t id = e.patch_index;
+      for (uint32_t cp : e.coverage.codepoints) {
+        subsets[id].insert(cp);
+      }
     }
 
     // add the base set to all entries.

--- a/ift/encoder/encoder_test.cc
+++ b/ift/encoder/encoder_test.cc
@@ -59,6 +59,7 @@ class EncoderTest : public ::testing::Test {
   FontData chunk2;
   FontData chunk3;
   FontData chunk4;
+
   uint32_t chunk0_cp = 0x47;
   uint32_t chunk1_cp = 0xb7;
   uint32_t chunk2_cp = 0xb2;

--- a/ift/ift_client.cc
+++ b/ift/ift_client.cc
@@ -20,6 +20,7 @@ using ift::proto::IFTB_ENCODING;
 using ift::proto::IFTTable;
 using ift::proto::PatchEncoding;
 using ift::proto::PatchMap;
+using ift::proto::PER_TABLE_SHARED_BROTLI_ENCODING;
 using ift::proto::SHARED_BROTLI_ENCODING;
 using patch_subset::BinaryPatch;
 using patch_subset::FontData;
@@ -176,6 +177,8 @@ StatusOr<const BinaryPatch*> IFTClient::PatcherFor(
       return brotli_binary_patch_.get();
     case IFTB_ENCODING:
       return iftb_binary_patch_.get();
+    case PER_TABLE_SHARED_BROTLI_ENCODING:
+      return per_table_binary_patch_.get();
     default:
       std::stringstream message;
       message << "Patch encoding " << encoding << " is not implemented.";

--- a/ift/ift_client.cc
+++ b/ift/ift_client.cc
@@ -189,8 +189,9 @@ Status IFTClient::SetFont(patch_subset::FontData&& new_font) {
   auto table = IFTTable::FromFont(face);
   if (table.ok()) {
     ift_table_ = std::move(*table);
-
-  } else if (!table.ok() && !absl::IsNotFound(table.status())) {
+  } else if (absl::IsNotFound(table.status())) {
+    ift_table_.reset();
+  } else if (!table.ok()) {
     hb_face_destroy(face);
     return table.status();
   }

--- a/ift/ift_client.cc
+++ b/ift/ift_client.cc
@@ -95,6 +95,12 @@ Status IFTClient::AddDesiredCodepoints(
   std::copy(codepoints.begin(), codepoints.end(),
             std::inserter(target_codepoints_, target_codepoints_.begin()));
 
+  // TODO(garretrieger): in some cases this may cause a needed patch
+  // to be replaced. However, the client  may still have fetched
+  // and added that replaced patch. Make sure the client supports this
+  // situation seemlessly (ignoring the no longer needed patch and should
+  // not attempt to apply it). Add a test in he integration tests which
+  // exercises this case.
   auto s = ComputeOutstandingPatches();
   if (!s.ok()) {
     status_ = s;

--- a/ift/ift_client.cc
+++ b/ift/ift_client.cc
@@ -1,7 +1,9 @@
 #include "ift/ift_client.h"
 
+#include <iterator>
 #include <sstream>
 
+#include "absl/container/btree_set.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "hb.h"
@@ -11,6 +13,7 @@
 #include "patch_subset/binary_patch.h"
 #include "patch_subset/font_data.h"
 
+using absl::btree_set;
 using absl::flat_hash_map;
 using absl::flat_hash_set;
 using absl::Status;
@@ -79,8 +82,150 @@ std::string IFTClient::PatchToUrl(const std::string& url_template,
   return out.str();
 }
 
-StatusOr<patch_set> IFTClient::PatchUrlsFor(
-    const hb_set_t& additional_codepoints) const {
+flat_hash_set<uint32_t> IFTClient::PatchesNeeded() const {
+  return outstanding_patches_;
+}
+
+Status IFTClient::AddDesiredCodepoints(
+    const absl::flat_hash_set<uint32_t>& codepoints) {
+  if (!status_.ok()) {
+    return status_;
+  }
+
+  std::copy(codepoints.begin(), codepoints.end(),
+            std::inserter(target_codepoints_, target_codepoints_.begin()));
+
+  auto s = ComputeOutstandingPatches();
+  if (!s.ok()) {
+    status_ = s;
+  }
+  return s;
+}
+
+void IFTClient::AddPatch(uint32_t id, const FontData& font_data) {
+  outstanding_patches_.erase(id);
+  pending_patches_[id].shallow_copy(font_data);
+}
+
+StatusOr<IFTClient::State> IFTClient::Process() {
+  // TODO(garretrieger): add a helper which classifies patches as
+  // dependent/independent instead of hardcoding here.
+  if (!status_.ok()) {
+    return status_;
+  }
+
+  if (!outstanding_patches_.empty()) {
+    return NEEDS_PATCHES;
+  }
+
+  if (pending_patches_.empty()) {
+    return READY;
+  }
+
+  // - When applying patches apply any dependent patches first.
+  // - There should only ever be one dependent patch in pending_pathches_.
+  // - If there are more that's an error.
+  // - Dependent patch applications may add more outstanding patches.
+  //   Return early if there are new outstanding patches.
+  // - Otherwise apply all pending independent patches.
+  std::optional<uint32_t> dependent_patch;
+  PatchEncoding dependent_patch_encoding;
+  std::vector<FontData> dependent_patch_data;
+  for (const auto& p : pending_patches_) {
+    uint32_t id = p.first;
+    const FontData& patch_data = p.second;
+
+    auto it = patch_to_encoding_.find(id);
+    if (it == patch_to_encoding_.end()) {
+      status_ =
+          absl::InternalError(StrCat("No encoding stored for patch ", id));
+      return status_;
+    }
+    PatchEncoding encoding = it->second;
+    if (!PatchMap::IsDependent(encoding)) {
+      continue;
+    }
+
+    if (dependent_patch) {
+      status_ = absl::InternalError(StrCat(
+          "Multiple dependent patches are pending. A max of one is allowed: ",
+          *dependent_patch, id));
+      return status_;
+    }
+
+    dependent_patch = id;
+    dependent_patch_encoding = encoding;
+    dependent_patch_data.resize(1);
+    dependent_patch_data[0].shallow_copy(patch_data);
+  }
+
+  if (dependent_patch) {
+    auto s = ApplyPatches(dependent_patch_data, dependent_patch_encoding);
+    if (!s.ok()) {
+      status_ = s;
+      return s;
+    }
+    pending_patches_.erase(*dependent_patch);
+
+    s = ComputeOutstandingPatches();
+    if (!s.ok()) {
+      status_ = s;
+      return s;
+    }
+
+    if (!outstanding_patches_.empty()) {
+      return NEEDS_PATCHES;
+    }
+  }
+
+  std::vector<uint32_t> indices;
+  std::vector<FontData> data;
+  for (const auto& p : pending_patches_) {
+    uint32_t id = p.first;
+    const FontData& patch_data = p.second;
+
+    auto it = patch_to_encoding_.find(id);
+    if (it == patch_to_encoding_.end()) {
+      status_ =
+          absl::InternalError(StrCat("No encoding stored for patch ", id));
+      return status_;
+    }
+    PatchEncoding encoding = it->second;
+    if (encoding != IFTB_ENCODING) {
+      continue;
+    }
+
+    indices.push_back(id);
+    FontData new_data;
+    new_data.shallow_copy(patch_data);
+    data.push_back(std::move(new_data));
+  }
+
+  if (!indices.empty()) {
+    auto s = ApplyPatches(data, IFTB_ENCODING);
+    if (!s.ok()) {
+      status_ = s;
+      return s;
+    }
+    for (uint32_t id : indices) {
+      pending_patches_.erase(id);
+    }
+  }
+
+  if (!pending_patches_.empty()) {
+    status_ = absl::InternalError(
+        "Pending patches remain after processing finished.");
+    return status_;
+  }
+
+  if (!outstanding_patches_.empty()) {
+    return NEEDS_PATCHES;
+  }
+
+  return READY;
+}
+
+Status IFTClient::ComputeOutstandingPatches() {
   // Patch matching algorithm works like this:
   // 1. Identify all patches listed in the IFT table which intersect the input
   // codepoints.
@@ -90,15 +235,17 @@ StatusOr<patch_set> IFTClient::PatchUrlsFor(
   //    coverage.
 
   if (!ift_table_) {
-    patch_set result;
-    return result;
+    outstanding_patches_.clear();
+    patch_to_encoding_.clear();
+    return absl::OkStatus();
   }
 
   absl::flat_hash_set<uint32_t> independent_entry_indices;
-  absl::flat_hash_set<uint32_t> dependent_entry_indices;
+  // keep dep entries sorted so that ties during single entry selection
+  // are broken consistently.
+  absl::btree_set<uint32_t> dependent_entry_indices;
 
-  hb_codepoint_t cp = HB_SET_VALUE_INVALID;
-  while (hb_set_next(&additional_codepoints, &cp)) {
+  for (uint32_t cp : target_codepoints_) {
     auto indices = codepoint_to_entries_index_.find(cp);
     if (indices == codepoint_to_entries_index_.end()) {
       continue;
@@ -113,45 +260,50 @@ StatusOr<patch_set> IFTClient::PatchUrlsFor(
         independent_entry_indices.insert(index);
       }
     }
-
-    if (!dependent_entry_indices.empty()) {
-      // Pick at most one dependent patches to keep.
-      // TODO(garretrieger): use intersection size with additional_codepoints
-      // instead.
-      // TODO(garretrieger): merge coverages when multiple entries have the same
-      // patch index.
-
-      uint32_t selected_entry_index;
-      uint32_t max_size = 0;
-      for (uint32_t entry_index : dependent_entry_indices) {
-        const PatchMap::Entry& entry =
-            ift_table_->GetPatchMap().GetEntries().at(entry_index);
-        if (entry.coverage.codepoints.size() > max_size) {
-          max_size = entry.coverage.codepoints.size();
-          selected_entry_index = entry_index;
-        }
-      }
-      independent_entry_indices.insert(selected_entry_index);
-    }
   }
 
-  patch_set result;
+  if (!dependent_entry_indices.empty()) {
+    // Pick at most one dependent patches to keep.
+    // TODO(garretrieger): use intersection size with additional_codepoints
+    // instead.
+    // TODO(garretrieger): merge coverages when multiple entries have the same
+    // patch index.
+
+    uint32_t selected_entry_index;
+    uint32_t max_size = 0;
+    for (uint32_t entry_index : dependent_entry_indices) {
+      const PatchMap::Entry& entry =
+          ift_table_->GetPatchMap().GetEntries().at(entry_index);
+      if (entry.coverage.codepoints.size() > max_size) {
+        max_size = entry.coverage.codepoints.size();
+        selected_entry_index = entry_index;
+      }
+    }
+
+    independent_entry_indices.insert(selected_entry_index);
+  }
+
+  outstanding_patches_.clear();
+  patch_to_encoding_.clear();
   for (uint32_t entry_index : independent_entry_indices) {
     const PatchMap::Entry& entry =
         ift_table_->GetPatchMap().GetEntries().at(entry_index);
-    std::string url =
-        IFTClient::PatchToUrl(ift_table_->GetUrlTemplate(), entry.patch_index);
 
     auto [it, was_inserted] =
-        result.insert(std::pair(std::move(url), entry.encoding));
+        patch_to_encoding_.insert(std::pair(entry.patch_index, entry.encoding));
     if (!was_inserted && it->second != entry.encoding) {
-      return absl::InternalError(StrCat("Invalid IFT table. patch URL,  ", url,
-                                        ", has conflicting encoding types: ",
-                                        entry.encoding, " != ", it->second));
+      return absl::InternalError(
+          StrCat("Invalid IFT table. patch ,  ", entry.patch_index,
+                 ", has conflicting encoding types: ", entry.encoding,
+                 " != ", it->second));
+    }
+
+    if (!pending_patches_.contains(entry.patch_index)) {
+      outstanding_patches_.insert(entry.patch_index);
     }
   }
 
-  return result;
+  return absl::OkStatus();
 }
 
 Status IFTClient::ApplyPatches(const std::vector<FontData>& patches,

--- a/ift/ift_client.h
+++ b/ift/ift_client.h
@@ -14,21 +14,25 @@
 
 namespace ift {
 
-typedef absl::btree_map<std::string, ift::proto::PatchEncoding> patch_set;
-
 /*
  * Client library for IFT fonts. Provides common operations needed by a client
  * trying to use an IFT font.
  */
 class IFTClient {
  public:
+  enum State {
+    NEEDS_PATCHES,
+    READY,
+  };
+
   static absl::StatusOr<IFTClient> NewClient(patch_subset::FontData&& font);
 
  private:
   IFTClient()
       : brotli_binary_patch_(new patch_subset::BrotliBinaryPatch()),
         iftb_binary_patch_(new ift::IftbBinaryPatch()),
-        per_table_binary_patch_(new ift::PerTableBrotliBinaryPatch()) {}
+        per_table_binary_patch_(new ift::PerTableBrotliBinaryPatch()),
+        status_(absl::OkStatus()) {}
 
  public:
   IFTClient(const IFTClient&) = delete;
@@ -42,7 +46,12 @@ class IFTClient {
         iftb_binary_patch_(std::move(other.iftb_binary_patch_)),
         per_table_binary_patch_(new ift::PerTableBrotliBinaryPatch()),
         codepoint_to_entries_index_(
-            std::move(other.codepoint_to_entries_index_)) {
+            std::move(other.codepoint_to_entries_index_)),
+        target_codepoints_(std::move(other.target_codepoints_)),
+        outstanding_patches_(std::move(other.outstanding_patches_)),
+        pending_patches_(std::move(other.pending_patches_)),
+        patch_to_encoding_(std::move(other.patch_to_encoding_)),
+        status_(other.status_) {
     other.face_ = nullptr;
   }
 
@@ -58,6 +67,11 @@ class IFTClient {
     brotli_binary_patch_ = std::move(other.brotli_binary_patch_);
     iftb_binary_patch_ = std::move(other.iftb_binary_patch_);
     codepoint_to_entries_index_ = std::move(other.codepoint_to_entries_index_);
+    target_codepoints_ = std::move(other.target_codepoints_);
+    outstanding_patches_ = std::move(other.outstanding_patches_);
+    pending_patches_ = std::move(other.pending_patches_);
+    patch_to_encoding_ = std::move(other.patch_to_encoding_);
+    status_ = other.status_;
 
     return *this;
   }
@@ -67,25 +81,50 @@ class IFTClient {
   static std::string PatchToUrl(const std::string& url_template,
                                 uint32_t patch_idx);
 
+  std::string PatchToUrl(uint32_t patch_idx) const {
+    return PatchToUrl(ift_table_->GetUrlTemplate(), patch_idx);
+  }
+
+  /*
+   * Returns the current version of the font. Once Process() returns READY then
+   * this font will have been extended to support all codepoints add via
+   * AddDesiredCodepoints().
+   */
   const patch_subset::FontData& GetFontData() { return font_; }
 
   /*
-   * Returns the set of patches needed to add support for all codepoints
-   * in 'additional_codepoints'.
+   * Returns the list of patches that need to be provided to finish processing
+   * the current extension request.
    */
-  absl::StatusOr<patch_set> PatchUrlsFor(
-      const hb_set_t& additional_codepoints) const;
+  absl::flat_hash_set<uint32_t> PatchesNeeded() const;
 
   /*
-   * Applies one or more 'patches' to 'font'. The patches are all encoded
-   * in the 'encoding' format.
-   *
-   * Returns the extended font.
+   * Adds a set of codepoints to the target subsets that the font should be
+   * extended to cover.
    */
+  absl::Status AddDesiredCodepoints(
+      const absl::flat_hash_set<uint32_t>& codepoints);
+
+  /*
+   * Adds patch data for a patch with the given id.
+   */
+  void AddPatch(uint32_t id, const patch_subset::FontData& font_data);
+
+  /*
+   * Call once requested patches have been supplied by AddPatch() in order to
+   * apply them. After processing further patches may be needed, which is
+   * indicated by returning the NEED_PATCHES state. If all processing is
+   * finished and the extended font subset is available returns the FINISHED
+   * state.
+   */
+  absl::StatusOr<State> Process();
+
+ private:
+  absl::Status ComputeOutstandingPatches();
+
   absl::Status ApplyPatches(const std::vector<patch_subset::FontData>& patches,
                             ift::proto::PatchEncoding encoding);
 
- private:
   absl::StatusOr<const patch_subset::BinaryPatch*> PatcherFor(
       ift::proto::PatchEncoding encoding) const;
 
@@ -103,6 +142,11 @@ class IFTClient {
 
   absl::flat_hash_map<uint32_t, std::vector<uint32_t>>
       codepoint_to_entries_index_;
+  absl::flat_hash_set<uint32_t> target_codepoints_;
+  absl::flat_hash_set<uint32_t> outstanding_patches_;
+  absl::flat_hash_map<uint32_t, patch_subset::FontData> pending_patches_;
+  absl::flat_hash_map<uint32_t, ift::proto::PatchEncoding> patch_to_encoding_;
+  absl::Status status_;
 };
 
 }  // namespace ift

--- a/ift/ift_client.h
+++ b/ift/ift_client.h
@@ -6,6 +6,7 @@
 #include "hb.h"
 #include "ift/iftb_binary_patch.h"
 #include "ift/proto/IFT.pb.h"
+#include "ift/proto/ift_table.h"
 #include "patch_subset/binary_patch.h"
 #include "patch_subset/brotli_binary_patch.h"
 #include "patch_subset/font_data.h"
@@ -20,19 +21,56 @@ typedef absl::btree_map<std::string, ift::proto::PatchEncoding> patch_set;
  */
 class IFTClient {
  public:
+  static absl::StatusOr<IFTClient> NewClient(patch_subset::FontData&& font);
+
+ private:
   IFTClient()
       : brotli_binary_patch_(new patch_subset::BrotliBinaryPatch()),
         iftb_binary_patch_(new ift::IftbBinaryPatch()) {}
 
+ public:
+  IFTClient(const IFTClient&) = delete;
+  IFTClient& operator=(const IFTClient&) = delete;
+
+  IFTClient(IFTClient&& other)
+      : font_(std::move(other.font_)),
+        face_(other.face_),
+        ift_table_(std::move(other.ift_table_)),
+        brotli_binary_patch_(std::move(other.brotli_binary_patch_)),
+        iftb_binary_patch_(std::move(other.iftb_binary_patch_)),
+        codepoint_to_entries_index_(
+            std::move(other.codepoint_to_entries_index_)) {
+    other.face_ = nullptr;
+  }
+
+  IFTClient& operator=(IFTClient&& other) {
+    if (this == &other) {
+      return *this;
+    }
+
+    font_ = std::move(other.font_);
+    face_ = other.face_;
+    other.face_ = nullptr;
+    ift_table_ = std::move(other.ift_table_);
+    brotli_binary_patch_ = std::move(other.brotli_binary_patch_);
+    iftb_binary_patch_ = std::move(other.iftb_binary_patch_);
+    codepoint_to_entries_index_ = std::move(other.codepoint_to_entries_index_);
+
+    return *this;
+  }
+
+  ~IFTClient() { hb_face_destroy(face_); }
+
   static std::string PatchToUrl(const std::string& url_template,
                                 uint32_t patch_idx);
+
+  const patch_subset::FontData& GetFontData() { return font_; }
 
   /*
    * Returns the set of patches needed to add support for all codepoints
    * in 'additional_codepoints'.
    */
   absl::StatusOr<patch_set> PatchUrlsFor(
-      const patch_subset::FontData& font,
       const hb_set_t& additional_codepoints) const;
 
   /*
@@ -41,17 +79,26 @@ class IFTClient {
    *
    * Returns the extended font.
    */
-  absl::StatusOr<patch_subset::FontData> ApplyPatches(
-      const patch_subset::FontData& font,
-      const std::vector<patch_subset::FontData>& patches,
-      ift::proto::PatchEncoding encoding) const;
+  absl::Status ApplyPatches(const std::vector<patch_subset::FontData>& patches,
+                            ift::proto::PatchEncoding encoding);
 
  private:
   absl::StatusOr<const patch_subset::BinaryPatch*> PatcherFor(
       ift::proto::PatchEncoding encoding) const;
 
+  absl::Status SetFont(patch_subset::FontData&& new_font);
+
+  void UpdateIndex();
+
+  patch_subset::FontData font_;
+  hb_face_t* face_ = nullptr;
+  std::optional<ift::proto::IFTTable> ift_table_;
+
   std::unique_ptr<patch_subset::BinaryPatch> brotli_binary_patch_;
   std::unique_ptr<ift::IftbBinaryPatch> iftb_binary_patch_;
+
+  absl::flat_hash_map<uint32_t, std::vector<uint32_t>>
+      codepoint_to_entries_index_;
 };
 
 }  // namespace ift

--- a/ift/ift_client.h
+++ b/ift/ift_client.h
@@ -5,6 +5,7 @@
 #include "absl/status/statusor.h"
 #include "hb.h"
 #include "ift/iftb_binary_patch.h"
+#include "ift/per_table_brotli_binary_patch.h"
 #include "ift/proto/IFT.pb.h"
 #include "ift/proto/ift_table.h"
 #include "patch_subset/binary_patch.h"
@@ -26,7 +27,8 @@ class IFTClient {
  private:
   IFTClient()
       : brotli_binary_patch_(new patch_subset::BrotliBinaryPatch()),
-        iftb_binary_patch_(new ift::IftbBinaryPatch()) {}
+        iftb_binary_patch_(new ift::IftbBinaryPatch()),
+        per_table_binary_patch_(new ift::PerTableBrotliBinaryPatch()) {}
 
  public:
   IFTClient(const IFTClient&) = delete;
@@ -38,6 +40,7 @@ class IFTClient {
         ift_table_(std::move(other.ift_table_)),
         brotli_binary_patch_(std::move(other.brotli_binary_patch_)),
         iftb_binary_patch_(std::move(other.iftb_binary_patch_)),
+        per_table_binary_patch_(new ift::PerTableBrotliBinaryPatch()),
         codepoint_to_entries_index_(
             std::move(other.codepoint_to_entries_index_)) {
     other.face_ = nullptr;
@@ -96,6 +99,7 @@ class IFTClient {
 
   std::unique_ptr<patch_subset::BinaryPatch> brotli_binary_patch_;
   std::unique_ptr<ift::IftbBinaryPatch> iftb_binary_patch_;
+  std::unique_ptr<ift::PerTableBrotliBinaryPatch> per_table_binary_patch_;
 
   absl::flat_hash_map<uint32_t, std::vector<uint32_t>>
       codepoint_to_entries_index_;

--- a/ift/iftb_binary_patch.cc
+++ b/ift/iftb_binary_patch.cc
@@ -105,9 +105,8 @@ Status IftbBinaryPatch::Patch(const FontData& font_base,
   // sfnt.write() needs to be called to realize table directory changes
   sfnt.write(false);
 
-  auto s = ift_table->RemovePatches(patch_indices);
-  if (!s.ok()) {
-    return s;
+  for (uint32_t patch_index : patch_indices) {
+    ift_table->GetPatchMap().RemoveEntries(patch_index);
   }
 
   hb_blob_t* blob = hb_blob_create(new_font_data.data(), new_length,

--- a/ift/iftb_binary_patch.cc
+++ b/ift/iftb_binary_patch.cc
@@ -22,7 +22,8 @@ using patch_subset::FontData;
 
 namespace ift {
 
-StatusOr<flat_hash_set<uint32_t>> IftbBinaryPatch::GidsInPatch(const FontData& patch) {
+StatusOr<flat_hash_set<uint32_t>> IftbBinaryPatch::GidsInPatch(
+    const FontData& patch) {
   // Format of the patch:
   // 0:  uint32        version
   // 4:  uint32        reserved
@@ -40,7 +41,7 @@ StatusOr<flat_hash_set<uint32_t>> IftbBinaryPatch::GidsInPatch(const FontData& p
   merger merger;
   std::string uncompressed;
   if (HB_TAG('I', 'F', 'T', 'C') !=
-        iftb::decodeBuffer(patch.data(), patch.size(), uncompressed)) {
+      iftb::decodeBuffer(patch.data(), patch.size(), uncompressed)) {
     return absl::InvalidArgumentError("Unsupported chunk type.");
   }
 
@@ -54,7 +55,8 @@ StatusOr<flat_hash_set<uint32_t>> IftbBinaryPatch::GidsInPatch(const FontData& p
   for (uint32_t i = 0; i < *glyph_count; i++) {
     auto gid = FontHelper::ReadUInt16(data.substr(gidsArrayOffset + 2 * i));
     if (!gid.ok()) {
-      return absl::InvalidArgumentError(StrCat("Failed to read gid at index ", i));
+      return absl::InvalidArgumentError(
+          StrCat("Failed to read gid at index ", i));
     }
     result.insert(*gid);
   }

--- a/ift/iftb_binary_patch.h
+++ b/ift/iftb_binary_patch.h
@@ -14,7 +14,8 @@ namespace ift {
 /* Applies one or more IFTB chunk file patches. */
 class IftbBinaryPatch : public patch_subset::BinaryPatch {
  public:
-  static absl::StatusOr<absl::flat_hash_set<uint32_t>> GidsInPatch(const patch_subset::FontData& patch);
+  static absl::StatusOr<absl::flat_hash_set<uint32_t>> GidsInPatch(
+      const patch_subset::FontData& patch);
 
   absl::Status Patch(
       const patch_subset::FontData& font_base,

--- a/ift/iftb_binary_patch.h
+++ b/ift/iftb_binary_patch.h
@@ -3,7 +3,9 @@
 
 #include <vector>
 
+#include "absl/container/flat_hash_set.h"
 #include "absl/status/status.h"
+#include "absl/status/statusor.h"
 #include "patch_subset/binary_patch.h"
 #include "patch_subset/font_data.h"
 
@@ -12,6 +14,8 @@ namespace ift {
 /* Applies one or more IFTB chunk file patches. */
 class IftbBinaryPatch : public patch_subset::BinaryPatch {
  public:
+  static absl::StatusOr<absl::flat_hash_set<uint32_t>> GidsInPatch(const patch_subset::FontData& patch);
+
   absl::Status Patch(
       const patch_subset::FontData& font_base,
       const patch_subset::FontData& patch,

--- a/ift/iftb_binary_patch.h
+++ b/ift/iftb_binary_patch.h
@@ -17,6 +17,9 @@ class IftbBinaryPatch : public patch_subset::BinaryPatch {
   static absl::StatusOr<absl::flat_hash_set<uint32_t>> GidsInPatch(
       const patch_subset::FontData& patch);
 
+  static absl::Status IdInPatch(const patch_subset::FontData& patch,
+                                uint32_t id_out[4]);
+
   absl::Status Patch(
       const patch_subset::FontData& font_base,
       const patch_subset::FontData& patch,

--- a/ift/iftb_binary_patch_test.cc
+++ b/ift/iftb_binary_patch_test.cc
@@ -77,16 +77,36 @@ StatusOr<uint32_t> glyph_size(const FontData& font_data,
   return *end - *start;
 }
 
+TEST_F(IftbBinaryPatchTest, GidsInPatch) {
+  auto gids = IftbBinaryPatch::GidsInPatch(chunk1);
+  ASSERT_TRUE(gids.ok()) << gids.status();
+
+  ASSERT_TRUE(gids->contains(313));
+  ASSERT_TRUE(gids->contains(354));
+  ASSERT_FALSE(gids->contains(71));
+  ASSERT_FALSE(gids->contains(802));
+
+  gids = IftbBinaryPatch::GidsInPatch(chunk4);
+  ASSERT_TRUE(gids.ok()) << gids.status();
+
+  ASSERT_TRUE(gids->contains(96));
+  ASSERT_TRUE(gids->contains(765));
+  ASSERT_TRUE(gids->contains(841));
+  ASSERT_TRUE(gids->contains(1032));
+  ASSERT_FALSE(gids->contains(313));
+  ASSERT_FALSE(gids->contains(354));
+}
+
 TEST_F(IftbBinaryPatchTest, SinglePatch) {
   FontData result;
   auto s = patcher.Patch(font, chunk2, &result);
   ASSERT_TRUE(s.ok()) << s;
   ASSERT_GT(result.size(), 1000);
 
-  /*
   auto ift_table = IFTTable::FromFont(result);
   ASSERT_TRUE(ift_table.ok()) << ift_table.status();
 
+  
   for (const auto& e : ift_table->GetPatchMap().GetEntries()) {
     uint32_t patch_index = e.patch_index;
     for (uint32_t codepoint : e.coverage.codepoints) {
@@ -97,6 +117,7 @@ TEST_F(IftbBinaryPatchTest, SinglePatch) {
     }
   }
 
+
   ASSERT_EQ(*glyph_size(result, 0xab), 0);
   ASSERT_EQ(*glyph_size(result, 0x2e8d), 0);
 
@@ -106,7 +127,6 @@ TEST_F(IftbBinaryPatchTest, SinglePatch) {
   ASSERT_LT(*glyph_size(result, 0xa5), 1000);
   ASSERT_GT(*glyph_size(result, 0x30d4), 1);
   ASSERT_LT(*glyph_size(result, 0x30d4), 1000);
-  */
 }
 
 TEST_F(IftbBinaryPatchTest, MultiplePatches) {

--- a/ift/iftb_binary_patch_test.cc
+++ b/ift/iftb_binary_patch_test.cc
@@ -83,16 +83,18 @@ TEST_F(IftbBinaryPatchTest, SinglePatch) {
   ASSERT_TRUE(s.ok()) << s;
   ASSERT_GT(result.size(), 1000);
 
+  /*
   auto ift_table = IFTTable::FromFont(result);
   ASSERT_TRUE(ift_table.ok()) << ift_table.status();
 
-  for (auto e : ift_table->GetPatchMap()) {
-    uint32_t codepoint = e.first;
-    uint32_t patch_index = e.second.first;
-    ASSERT_NE(patch_index, 2);
-    // spot check a couple of codepoints that should be removed.
-    ASSERT_NE(codepoint, 0xa5);
-    ASSERT_NE(codepoint, 0x30d4);
+  for (const auto& e : ift_table->GetPatchMap().GetEntries()) {
+    uint32_t patch_index = e.patch_index;
+    for (uint32_t codepoint : e.coverage.codepoints) {
+      ASSERT_NE(patch_index, 2);
+      // spot check a couple of codepoints that should be removed.
+      ASSERT_NE(codepoint, 0xa5);
+      ASSERT_NE(codepoint, 0x30d4);
+    }
   }
 
   ASSERT_EQ(*glyph_size(result, 0xab), 0);
@@ -104,6 +106,7 @@ TEST_F(IftbBinaryPatchTest, SinglePatch) {
   ASSERT_LT(*glyph_size(result, 0xa5), 1000);
   ASSERT_GT(*glyph_size(result, 0x30d4), 1);
   ASSERT_LT(*glyph_size(result, 0x30d4), 1000);
+  */
 }
 
 TEST_F(IftbBinaryPatchTest, MultiplePatches) {
@@ -118,15 +121,16 @@ TEST_F(IftbBinaryPatchTest, MultiplePatches) {
   auto ift_table = IFTTable::FromFont(result);
   ASSERT_TRUE(ift_table.ok()) << ift_table.status();
 
-  for (auto e : ift_table->GetPatchMap()) {
-    uint32_t codepoint = e.first;
-    uint32_t patch_index = e.second.first;
-    ASSERT_NE(patch_index, 2);
-    ASSERT_NE(patch_index, 3);
-    // spot check a couple of codepoints that should be removed.
-    ASSERT_NE(codepoint, 0xa5);
-    ASSERT_NE(codepoint, 0xeb);
-    ASSERT_NE(codepoint, 0x30d4);
+  for (const auto& e : ift_table->GetPatchMap().GetEntries()) {
+    uint32_t patch_index = e.patch_index;
+    for (uint32_t codepoint : e.coverage.codepoints) {
+      ASSERT_NE(patch_index, 2);
+      ASSERT_NE(patch_index, 3);
+      // spot check a couple of codepoints that should be removed.
+      ASSERT_NE(codepoint, 0xa5);
+      ASSERT_NE(codepoint, 0xeb);
+      ASSERT_NE(codepoint, 0x30d4);
+    }
   }
 
   ASSERT_EQ(*glyph_size(result, 0xab), 0);

--- a/ift/iftb_binary_patch_test.cc
+++ b/ift/iftb_binary_patch_test.cc
@@ -128,6 +128,17 @@ TEST_F(IftbBinaryPatchTest, GidsInPatch) {
   ASSERT_FALSE(gids->contains(354));
 }
 
+TEST_F(IftbBinaryPatchTest, IdInPatch) {
+  uint32_t id[4];
+  auto sc = IftbBinaryPatch::IdInPatch(chunk1, id);
+  ASSERT_TRUE(sc.ok()) << sc;
+
+  ASSERT_EQ(id[0], 0x3c2bfda0);
+  ASSERT_EQ(id[1], 0x890625c9);
+  ASSERT_EQ(id[2], 0x40c644de);
+  ASSERT_EQ(id[3], 0xb1195627);
+}
+
 TEST_F(IftbBinaryPatchTest, SinglePatch) {
   FontData result;
   auto s = patcher.Patch(font, chunk2, &result);

--- a/ift/iftb_binary_patch_test.cc
+++ b/ift/iftb_binary_patch_test.cc
@@ -50,17 +50,7 @@ class IftbBinaryPatchTest : public ::testing::Test {
             HB_SUBSET_FLAGS_IFTB_REQUIREMENTS | HB_SUBSET_FLAGS_NOTDEF_OUTLINE);
 
     hb_face_t* subset = hb_subset_or_fail(face, input);
-    std::vector<hb_tag_t> tags = FontHelper::GetOrderedTags(subset);
-    std::vector<hb_tag_t> new_order;
-    for (hb_tag_t t : tags) {
-      if (t != FontHelper::kGlyf && t != FontHelper::kLoca) {
-        new_order.push_back(t);
-      }
-    }
-    new_order.push_back(FontHelper::kGlyf);
-    new_order.push_back(FontHelper::kLoca);
-    new_order.push_back(0);
-    hb_face_builder_sort_tables(subset, new_order.data());
+    FontHelper::ApplyIftbTableOrdering(subset);
 
     FontData result(subset);
 

--- a/ift/iftb_binary_patch_test.cc
+++ b/ift/iftb_binary_patch_test.cc
@@ -106,7 +106,6 @@ TEST_F(IftbBinaryPatchTest, SinglePatch) {
   auto ift_table = IFTTable::FromFont(result);
   ASSERT_TRUE(ift_table.ok()) << ift_table.status();
 
-  
   for (const auto& e : ift_table->GetPatchMap().GetEntries()) {
     uint32_t patch_index = e.patch_index;
     for (uint32_t codepoint : e.coverage.codepoints) {
@@ -116,7 +115,6 @@ TEST_F(IftbBinaryPatchTest, SinglePatch) {
       ASSERT_NE(codepoint, 0x30d4);
     }
   }
-
 
   ASSERT_EQ(*glyph_size(result, 0xab), 0);
   ASSERT_EQ(*glyph_size(result, 0x2e8d), 0);

--- a/ift/integration_test.cc
+++ b/ift/integration_test.cc
@@ -145,10 +145,6 @@ class IntegrationTest : public ::testing::Test {
 };
 
 // TODO(garretrieger): add IFTB only test case.
-// TODO(garretrieger): add shared brotli only test case.
-// TODO(garretrieger): add test case where changing the
-//  target codepoints causes the dependent patch selection
-//  to change.
 
 TEST_F(IntegrationTest, SharedBrotliOnly) {
   Encoder encoder;
@@ -238,6 +234,68 @@ TEST_F(IntegrationTest, SharedBrotliMultiple) {
   // Phase 2
   patches = client->PatchesNeeded();
   ASSERT_EQ(patches.size(), 1);
+
+  sc = AddPatchesSbr(*client, encoder);
+  ASSERT_TRUE(sc.ok()) << sc;
+
+  state = client->Process();
+  ASSERT_TRUE(state.ok()) << state.status();
+  ASSERT_EQ(*state, IFTClient::READY);
+
+  codepoints = ToCodepointsSet(client->GetFontData());
+  ASSERT_TRUE(codepoints.contains(0x41));
+  ASSERT_FALSE(codepoints.contains(0x45));
+  ASSERT_TRUE(codepoints.contains(0x48));
+  ASSERT_FALSE(codepoints.contains(0x4B));
+  ASSERT_TRUE(codepoints.contains(0x4E));
+}
+
+TEST_F(IntegrationTest, SharedBrotli_AddCodepointsWhileInProgress) {
+  Encoder encoder;
+  auto sc = InitEncoderForSharedBrotli(encoder);
+  ASSERT_TRUE(sc.ok()) << sc;
+
+  sc = encoder.SetBaseSubset({0x41, 0x42, 0x43});
+  encoder.AddExtensionSubset({0x45, 0x46, 0x47});
+  encoder.AddExtensionSubset({0x48, 0x49, 0x4A});
+  encoder.AddExtensionSubset({0x4B, 0x4C, 0x4D});
+  encoder.AddExtensionSubset({0x4E, 0x4F, 0x50, 0x51});
+  ASSERT_TRUE(sc.ok()) << sc;
+
+  auto encoded = encoder.Encode();
+  ASSERT_TRUE(encoded.ok()) << encoded.status();
+
+  auto codepoints = ToCodepointsSet(*encoded);
+  ASSERT_TRUE(codepoints.contains(0x41));
+  ASSERT_FALSE(codepoints.contains(0x45));
+  ASSERT_FALSE(codepoints.contains(0x48));
+  ASSERT_FALSE(codepoints.contains(0x4B));
+  ASSERT_FALSE(codepoints.contains(0x4E));
+
+  auto client = IFTClient::NewClient(std::move(*encoded));
+  ASSERT_TRUE(client.ok()) << client.status();
+
+  sc = client->AddDesiredCodepoints({0x49});
+  ASSERT_TRUE(sc.ok()) << sc;
+
+  flat_hash_set<uint32_t> patches_expected = {1};
+  auto patches = client->PatchesNeeded();
+  ASSERT_EQ(patches, patches_expected);
+
+  sc = client->AddDesiredCodepoints({0x4F});
+  ASSERT_TRUE(sc.ok()) << sc;
+
+  patches_expected = {3};
+  patches = client->PatchesNeeded();
+  ASSERT_EQ(patches, patches_expected);
+
+  // Patch resolution
+  sc = AddPatchesSbr(*client, encoder);
+  ASSERT_TRUE(sc.ok()) << sc;
+
+  auto state = client->Process();
+  ASSERT_TRUE(state.ok()) << state.status();
+  ASSERT_EQ(*state, IFTClient::NEEDS_PATCHES);
 
   sc = AddPatchesSbr(*client, encoder);
   ASSERT_TRUE(sc.ok()) << sc;

--- a/ift/integration_test.cc
+++ b/ift/integration_test.cc
@@ -1,0 +1,186 @@
+#include <iterator>
+#include <string>
+
+#include "absl/container/flat_hash_set.h"
+#include "absl/strings/str_cat.h"
+#include "gtest/gtest.h"
+#include "hb.h"
+#include "ift/encoder/encoder.h"
+#include "ift/ift_client.h"
+#include "patch_subset/font_data.h"
+#include "patch_subset/hb_set_unique_ptr.h"
+
+using absl::flat_hash_set;
+using absl::StrCat;
+using ift::encoder::Encoder;
+using ift::IFTClient;
+using patch_subset::FontData;
+using patch_subset::hb_set_unique_ptr;
+using patch_subset::make_hb_set;
+using ift::proto::PatchEncoding;
+using ift::proto::PER_TABLE_SHARED_BROTLI_ENCODING;
+using ift::proto::IFTB_ENCODING;
+
+namespace ift {
+
+class IntegrationTest : public ::testing::Test {
+ protected:
+  IntegrationTest() {
+    hb_blob_t* blob =
+        hb_blob_create_from_file("ift/testdata/NotoSansJP-Regular.subset.ttf");
+    hb_face_t* face = hb_face_create(blob, 0);
+    hb_blob_destroy(blob);
+    noto_sans_jp_.set(face);
+    hb_face_destroy(face);
+
+    hb_map_t* gid_to_unicode = GidToUnicodeMap(face);
+
+    iftb_patches_.resize(5);
+    iftb_subset_gids_.resize(5);
+    iftb_subsets_.resize(5);
+    for (int i = 1; i <= 4; i++) {
+      std::string name =
+          StrCat("ift/testdata/NotoSansJP-Regular.subset_iftb/chunk", i, ".br");
+      blob = hb_blob_create_from_file(name.c_str());
+      assert(hb_blob_get_length(blob) > 0);
+      iftb_patches_[i].set(blob);
+      hb_blob_destroy(blob);
+    }
+
+    iftb_subset_gids_[1] = {158, 160, 165, 166, 167, 168, 186};
+    iftb_subset_gids_[2] = {159, 162, 171, 172, 175, 177, 184};
+    iftb_subset_gids_[3] = {169};
+    iftb_subset_gids_[4] = {161, 163, 164, 170, 173, 174, 176, 178,
+                            179, 180, 181, 182, 183, 185, 187};
+
+    for (int i = 1; i <= 4; i++) {
+      for (uint32_t gid : iftb_subset_gids_[i]) {
+        uint32_t cp = hb_map_get(gid_to_unicode, gid);
+        assert(cp != (uint32_t) -1);
+        iftb_subsets_[i].insert(cp);
+      }
+    }
+
+    sbr_subsets_.resize(3);
+    std::copy(iftb_subsets_[1].begin(), iftb_subsets_[1].end(),
+              std::inserter(sbr_subsets_[0], sbr_subsets_[0].begin()));
+
+    std::copy(iftb_subsets_[2].begin(), iftb_subsets_[2].end(),
+              std::inserter(sbr_subsets_[1], sbr_subsets_[1].begin()));
+
+    std::copy(iftb_subsets_[3].begin(), iftb_subsets_[3].end(),
+              std::inserter(sbr_subsets_[2], sbr_subsets_[2].begin()));
+    std::copy(iftb_subsets_[4].begin(), iftb_subsets_[4].end(),
+              std::inserter(sbr_subsets_[2], sbr_subsets_[2].begin()));
+
+    hb_map_destroy(gid_to_unicode);
+  }
+
+  hb_map_t* GidToUnicodeMap(hb_face_t* face) {
+    hb_map_t* unicode_to_gid = hb_map_create ();
+    hb_face_collect_nominal_glyph_mapping(face, unicode_to_gid, nullptr);
+
+    hb_map_t* gid_to_unicode = hb_map_create();
+    int index = -1;
+    uint32_t cp = HB_MAP_VALUE_INVALID;
+    uint32_t gid = HB_MAP_VALUE_INVALID;
+    while (hb_map_next(unicode_to_gid, &index, &cp, &gid)) {
+      hb_map_set(gid_to_unicode, gid, cp);
+    }
+
+    hb_map_destroy(unicode_to_gid);
+    return gid_to_unicode;
+  }
+
+  FontData noto_sans_jp_;
+  std::vector<FontData> iftb_patches_;
+  std::vector<flat_hash_set<uint32_t>> iftb_subset_gids_;
+  std::vector<flat_hash_set<uint32_t>> iftb_subsets_;
+  std::vector<flat_hash_set<uint32_t>> sbr_subsets_;
+};
+
+TEST_F(IntegrationTest, MixedMode) {
+  Encoder encoder;
+  encoder.SetUrlTemplate("$2$1");
+  auto sc = encoder.SetId({
+    0x3c2bfda0,
+    0x890625c9,
+    0x40c644de,
+    0xb1195627
+  });
+  ASSERT_TRUE(sc.ok()) << sc;
+
+  for (int i = 1; i <= 4; i++) {
+    encoder.AddExistingIftbPatch(i, iftb_subsets_[i]);
+  }
+
+  hb_face_t* face = noto_sans_jp_.reference_face();
+  std::vector<const absl::flat_hash_set<hb_codepoint_t>*> subsets = {
+      &(sbr_subsets_[1]), &(sbr_subsets_[2])};
+  auto encoded = encoder.Encode(face, sbr_subsets_[0], subsets);
+  hb_face_destroy(face);
+  ASSERT_TRUE(encoded.ok()) << encoded.status();
+
+  hb_set_unique_ptr unicodes = make_hb_set();
+  face = encoded->reference_face();
+  hb_face_collect_unicodes(face, unicodes.get());
+  for (uint32_t cp : sbr_subsets_[0]) {
+    ASSERT_TRUE(hb_set_has(unicodes.get(), cp));
+  }
+  for (uint32_t cp : sbr_subsets_[1]) {
+    ASSERT_FALSE(hb_set_has(unicodes.get(), cp));
+  }
+  hb_face_destroy(face);
+
+  auto client = IFTClient::NewClient(std::move(*encoded));
+  ASSERT_TRUE(client.ok()) << client.status();
+
+  // gids 161, 163, 164
+  hb_set_unique_ptr input = make_hb_set(3, 0xe3, 0xe5, 0xe6);
+  auto patches = client->PatchUrlsFor(*input);
+  ASSERT_TRUE(patches.ok()) << patches.status();
+
+  for (PatchEncoding target_encoding : {PER_TABLE_SHARED_BROTLI_ENCODING, IFTB_ENCODING}) {
+    for (const auto& p : *patches) {
+      std::string url = p.first;
+      PatchEncoding encoding = p.second;
+      uint32_t id = std::stoul(url);
+
+      if (encoding != target_encoding) {
+        continue;
+      }
+
+      std::vector<FontData> patch_data;
+      patch_data.resize(1);
+      if (id <= 4) {
+        patch_data[0].shallow_copy(iftb_patches_[id]);
+      } else {
+        auto it = encoder.Patches().find(id);
+        ASSERT_TRUE(it != encoder.Patches().end());
+        patch_data[0].shallow_copy(it->second);
+      }
+
+      printf("Applying patch %u with encoding %u\n", id, encoding);
+      auto s = client->ApplyPatches(patch_data, encoding);
+      ASSERT_TRUE(s.ok()) << s;
+    }
+  }
+
+  face = client->GetFontData().reference_face();
+  hb_set_clear(unicodes.get());
+  hb_face_collect_unicodes(face, unicodes.get());
+  hb_face_destroy(face);
+
+  ASSERT_FALSE(hb_set_has(unicodes.get(), 159));
+  ASSERT_TRUE(hb_set_has(unicodes.get(), 160));
+  ASSERT_TRUE(hb_set_has(unicodes.get(), 161));
+  ASSERT_TRUE(hb_set_has(unicodes.get(), 163));
+  ASSERT_TRUE(hb_set_has(unicodes.get(), 164));
+  ASSERT_TRUE(hb_set_has(unicodes.get(), 169));
+  
+  // TODO check glyph presence as well.
+  //   - We can extract the functions in iftb_binary_patch_test for dealing with glyf/loca.
+  //   - Need to ensure loca is long to use those.
+}
+
+}  // namespace ift

--- a/ift/integration_test.cc
+++ b/ift/integration_test.cc
@@ -10,6 +10,7 @@
 #include "patch_subset/font_data.h"
 #include "patch_subset/hb_set_unique_ptr.h"
 
+using absl::btree_set;
 using absl::flat_hash_set;
 using absl::StrCat;
 using ift::IFTClient;
@@ -33,11 +34,7 @@ class IntegrationTest : public ::testing::Test {
     noto_sans_jp_.set(face);
     hb_face_destroy(face);
 
-    hb_map_t* gid_to_unicode = GidToUnicodeMap(face);
-
     iftb_patches_.resize(5);
-    iftb_subset_gids_.resize(5);
-    iftb_subsets_.resize(5);
     for (int i = 1; i <= 4; i++) {
       std::string name =
           StrCat("ift/testdata/NotoSansJP-Regular.subset_iftb/chunk", i, ".br");
@@ -46,94 +43,73 @@ class IntegrationTest : public ::testing::Test {
       iftb_patches_[i].set(blob);
       hb_blob_destroy(blob);
     }
-
-    iftb_subset_gids_[1] = {158, 160, 165, 166, 167, 168, 186};
-    iftb_subset_gids_[2] = {159, 162, 171, 172, 175, 177, 184};
-    iftb_subset_gids_[3] = {169};
-    iftb_subset_gids_[4] = {161, 163, 164, 170, 173, 174, 176, 178,
-                            179, 180, 181, 182, 183, 185, 187};
-
-    for (int i = 1; i <= 4; i++) {
-      for (uint32_t gid : iftb_subset_gids_[i]) {
-        uint32_t cp = hb_map_get(gid_to_unicode, gid);
-        assert(cp != (uint32_t)-1);
-        iftb_subsets_[i].insert(cp);
-      }
-    }
-
-    sbr_subsets_.resize(3);
-    std::copy(iftb_subsets_[1].begin(), iftb_subsets_[1].end(),
-              std::inserter(sbr_subsets_[0], sbr_subsets_[0].begin()));
-
-    std::copy(iftb_subsets_[2].begin(), iftb_subsets_[2].end(),
-              std::inserter(sbr_subsets_[1], sbr_subsets_[1].begin()));
-
-    std::copy(iftb_subsets_[3].begin(), iftb_subsets_[3].end(),
-              std::inserter(sbr_subsets_[2], sbr_subsets_[2].begin()));
-    std::copy(iftb_subsets_[4].begin(), iftb_subsets_[4].end(),
-              std::inserter(sbr_subsets_[2], sbr_subsets_[2].begin()));
-
-    hb_map_destroy(gid_to_unicode);
   }
 
-  hb_map_t* GidToUnicodeMap(hb_face_t* face) {
-    hb_map_t* unicode_to_gid = hb_map_create();
-    hb_face_collect_nominal_glyph_mapping(face, unicode_to_gid, nullptr);
+  btree_set<uint32_t> ToCodepointsSet(const FontData& font_data) {
+    hb_face_t* face = font_data.reference_face();
 
-    hb_map_t* gid_to_unicode = hb_map_create();
-    int index = -1;
-    uint32_t cp = HB_MAP_VALUE_INVALID;
-    uint32_t gid = HB_MAP_VALUE_INVALID;
-    while (hb_map_next(unicode_to_gid, &index, &cp, &gid)) {
-      hb_map_set(gid_to_unicode, gid, cp);
+    hb_set_unique_ptr codepoints = patch_subset::make_hb_set();
+    hb_face_collect_unicodes(face, codepoints.get());
+    hb_face_destroy(face);
+
+    btree_set<uint32_t> result;
+    hb_codepoint_t cp = HB_SET_VALUE_INVALID;
+    while (hb_set_next(codepoints.get(), &cp)) {
+      result.insert(cp);
     }
 
-    hb_map_destroy(unicode_to_gid);
-    return gid_to_unicode;
+    return result;
   }
 
   FontData noto_sans_jp_;
   std::vector<FontData> iftb_patches_;
-  std::vector<flat_hash_set<uint32_t>> iftb_subset_gids_;
-  std::vector<flat_hash_set<uint32_t>> iftb_subsets_;
-  std::vector<flat_hash_set<uint32_t>> sbr_subsets_;
+
+  uint32_t chunk0_cp = 0x47;
+  uint32_t chunk1_cp = 0xb7;
+  uint32_t chunk2_cp = 0xb2;
+  uint32_t chunk3_cp = 0xeb;
+  uint32_t chunk4_cp = 0xa8;
 };
 
 TEST_F(IntegrationTest, MixedMode) {
   Encoder encoder;
   encoder.SetUrlTemplate("$2$1");
+  {
+    hb_face_t* face = noto_sans_jp_.reference_face();
+    encoder.SetFace(face);
+    hb_face_destroy(face);
+  }
   auto sc = encoder.SetId({0x3c2bfda0, 0x890625c9, 0x40c644de, 0xb1195627});
   ASSERT_TRUE(sc.ok()) << sc;
 
   for (int i = 1; i <= 4; i++) {
-    encoder.AddExistingIftbPatch(i, iftb_subsets_[i]);
+    auto sc = encoder.AddExistingIftbPatch(i, iftb_patches_[i]);
+    ASSERT_TRUE(sc.ok()) << sc;
   }
 
-  hb_face_t* face = noto_sans_jp_.reference_face();
-  std::vector<const absl::flat_hash_set<hb_codepoint_t>*> subsets = {
-      &(sbr_subsets_[1]), &(sbr_subsets_[2])};
-  auto encoded = encoder.Encode(face, sbr_subsets_[0], subsets);
-  hb_face_destroy(face);
+  // target paritions: {{0, 1}, {2}, {3, 4}}
+  sc = encoder.SetBaseSubsetFromIftbPatches({1});
+  sc.Update(encoder.AddExtensionSubsetOfIftbPatches({2}));
+  sc.Update(encoder.AddExtensionSubsetOfIftbPatches({3, 4}));
+  ASSERT_TRUE(sc.ok()) << sc;
+
+  auto encoded = encoder.Encode();
   ASSERT_TRUE(encoded.ok()) << encoded.status();
 
-  hb_set_unique_ptr unicodes = make_hb_set();
-  face = encoded->reference_face();
-  hb_face_collect_unicodes(face, unicodes.get());
-  for (uint32_t cp : sbr_subsets_[0]) {
-    ASSERT_TRUE(hb_set_has(unicodes.get(), cp));
-  }
-  for (uint32_t cp : sbr_subsets_[1]) {
-    ASSERT_FALSE(hb_set_has(unicodes.get(), cp));
-  }
-  hb_face_destroy(face);
+  auto codepoints = ToCodepointsSet(*encoded);
+  ASSERT_TRUE(codepoints.contains(chunk0_cp));
+  ASSERT_TRUE(codepoints.contains(chunk1_cp));
+  ASSERT_FALSE(codepoints.contains(chunk2_cp));
+  ASSERT_FALSE(codepoints.contains(chunk3_cp));
+  ASSERT_FALSE(codepoints.contains(chunk4_cp));
 
   auto client = IFTClient::NewClient(std::move(*encoded));
   ASSERT_TRUE(client.ok()) << client.status();
 
-  // gids 161, 163, 164
-  hb_set_unique_ptr input = make_hb_set(3, 0xe3, 0xe5, 0xe6);
+  hb_set_unique_ptr input = make_hb_set(2, chunk3_cp, chunk4_cp);
   auto patches = client->PatchUrlsFor(*input);
   ASSERT_TRUE(patches.ok()) << patches.status();
+  ASSERT_EQ(patches->size(), 3);  // 1 shared brotli and 2 iftb.
 
   for (PatchEncoding target_encoding :
        {PER_TABLE_SHARED_BROTLI_ENCODING, IFTB_ENCODING}) {
@@ -156,28 +132,21 @@ TEST_F(IntegrationTest, MixedMode) {
         patch_data[0].shallow_copy(it->second);
       }
 
-      printf("Applying patch %u with encoding %u\n", id, encoding);
       auto s = client->ApplyPatches(patch_data, encoding);
       ASSERT_TRUE(s.ok()) << s;
     }
   }
 
-  face = client->GetFontData().reference_face();
-  hb_set_clear(unicodes.get());
-  hb_face_collect_unicodes(face, unicodes.get());
-  hb_face_destroy(face);
+  codepoints = ToCodepointsSet(client->GetFontData());
+  ASSERT_TRUE(codepoints.contains(chunk0_cp));
+  ASSERT_TRUE(codepoints.contains(chunk1_cp));
+  ASSERT_FALSE(codepoints.contains(chunk2_cp));
+  ASSERT_TRUE(codepoints.contains(chunk3_cp));
+  ASSERT_TRUE(codepoints.contains(chunk4_cp));
 
-  ASSERT_FALSE(hb_set_has(unicodes.get(), 159));
-  ASSERT_TRUE(hb_set_has(unicodes.get(), 160));
-  ASSERT_TRUE(hb_set_has(unicodes.get(), 161));
-  ASSERT_TRUE(hb_set_has(unicodes.get(), 163));
-  ASSERT_TRUE(hb_set_has(unicodes.get(), 164));
-  ASSERT_TRUE(hb_set_has(unicodes.get(), 169));
-
-  // TODO check glyph presence as well.
+  // TODO(garretrieger): check glyph presence as well.
   //   - We can extract the functions in iftb_binary_patch_test for dealing with
   //   glyf/loca.
-  //   - Need to ensure loca is long to use those.
 }
 
 }  // namespace ift

--- a/ift/integration_test.cc
+++ b/ift/integration_test.cc
@@ -12,14 +12,14 @@
 
 using absl::flat_hash_set;
 using absl::StrCat;
-using ift::encoder::Encoder;
 using ift::IFTClient;
+using ift::encoder::Encoder;
+using ift::proto::IFTB_ENCODING;
+using ift::proto::PatchEncoding;
+using ift::proto::PER_TABLE_SHARED_BROTLI_ENCODING;
 using patch_subset::FontData;
 using patch_subset::hb_set_unique_ptr;
 using patch_subset::make_hb_set;
-using ift::proto::PatchEncoding;
-using ift::proto::PER_TABLE_SHARED_BROTLI_ENCODING;
-using ift::proto::IFTB_ENCODING;
 
 namespace ift {
 
@@ -56,7 +56,7 @@ class IntegrationTest : public ::testing::Test {
     for (int i = 1; i <= 4; i++) {
       for (uint32_t gid : iftb_subset_gids_[i]) {
         uint32_t cp = hb_map_get(gid_to_unicode, gid);
-        assert(cp != (uint32_t) -1);
+        assert(cp != (uint32_t)-1);
         iftb_subsets_[i].insert(cp);
       }
     }
@@ -77,7 +77,7 @@ class IntegrationTest : public ::testing::Test {
   }
 
   hb_map_t* GidToUnicodeMap(hb_face_t* face) {
-    hb_map_t* unicode_to_gid = hb_map_create ();
+    hb_map_t* unicode_to_gid = hb_map_create();
     hb_face_collect_nominal_glyph_mapping(face, unicode_to_gid, nullptr);
 
     hb_map_t* gid_to_unicode = hb_map_create();
@@ -102,12 +102,7 @@ class IntegrationTest : public ::testing::Test {
 TEST_F(IntegrationTest, MixedMode) {
   Encoder encoder;
   encoder.SetUrlTemplate("$2$1");
-  auto sc = encoder.SetId({
-    0x3c2bfda0,
-    0x890625c9,
-    0x40c644de,
-    0xb1195627
-  });
+  auto sc = encoder.SetId({0x3c2bfda0, 0x890625c9, 0x40c644de, 0xb1195627});
   ASSERT_TRUE(sc.ok()) << sc;
 
   for (int i = 1; i <= 4; i++) {
@@ -140,7 +135,8 @@ TEST_F(IntegrationTest, MixedMode) {
   auto patches = client->PatchUrlsFor(*input);
   ASSERT_TRUE(patches.ok()) << patches.status();
 
-  for (PatchEncoding target_encoding : {PER_TABLE_SHARED_BROTLI_ENCODING, IFTB_ENCODING}) {
+  for (PatchEncoding target_encoding :
+       {PER_TABLE_SHARED_BROTLI_ENCODING, IFTB_ENCODING}) {
     for (const auto& p : *patches) {
       std::string url = p.first;
       PatchEncoding encoding = p.second;
@@ -177,9 +173,10 @@ TEST_F(IntegrationTest, MixedMode) {
   ASSERT_TRUE(hb_set_has(unicodes.get(), 163));
   ASSERT_TRUE(hb_set_has(unicodes.get(), 164));
   ASSERT_TRUE(hb_set_has(unicodes.get(), 169));
-  
+
   // TODO check glyph presence as well.
-  //   - We can extract the functions in iftb_binary_patch_test for dealing with glyf/loca.
+  //   - We can extract the functions in iftb_binary_patch_test for dealing with
+  //   glyf/loca.
   //   - Need to ensure loca is long to use those.
 }
 

--- a/ift/integration_test.cc
+++ b/ift/integration_test.cc
@@ -25,10 +25,6 @@ using patch_subset::make_hb_set;
 
 namespace ift {
 
-// TODO(garretrieger): test a case where an additional patch is required after
-// initial
-//                     dependent patch application.
-
 class IntegrationTest : public ::testing::Test {
  protected:
   IntegrationTest() {
@@ -66,7 +62,7 @@ class IntegrationTest : public ::testing::Test {
     return result;
   }
 
-  Status InitEncoder(Encoder& encoder) {
+  Status InitEncoderForIftb(Encoder& encoder) {
     encoder.SetUrlTemplate("$2$1");
     {
       hb_face_t* face = noto_sans_jp_.reference_face();
@@ -118,9 +114,15 @@ class IntegrationTest : public ::testing::Test {
   uint32_t chunk4_cp = 0xa8;
 };
 
+// TODO(garretrieger): add IFTB only test case.
+// TODO(garretrieger): add shared brotli only test case.
+// TODO(garretrieger): add test case where changing the
+//  target codepoints causes the dependent patch selection
+//  to change.
+
 TEST_F(IntegrationTest, MixedMode) {
   Encoder encoder;
-  auto sc = InitEncoder(encoder);
+  auto sc = InitEncoderForIftb(encoder);
   ASSERT_TRUE(sc.ok()) << sc;
 
   // target paritions: {{0, 1}, {2}, {3, 4}}
@@ -169,7 +171,7 @@ TEST_F(IntegrationTest, MixedMode) {
 
 TEST_F(IntegrationTest, MixedMode_SequentialDependentPatches) {
   Encoder encoder;
-  auto sc = InitEncoder(encoder);
+  auto sc = InitEncoderForIftb(encoder);
   ASSERT_TRUE(sc.ok()) << sc;
 
   // target paritions: {{0, 1}, {2}, {3}, {4}}

--- a/ift/per_table_brotli_binary_diff.cc
+++ b/ift/per_table_brotli_binary_diff.cc
@@ -1,0 +1,81 @@
+#include "ift/per_table_brotli_binary_diff.h"
+
+#include "absl/container/flat_hash_set.h"
+#include "common/font_helper.h"
+#include "hb.h"
+#include "ift/proto/IFT.pb.h"
+#include "patch_subset/font_data.h"
+
+using absl::btree_set;
+using absl::flat_hash_set;
+using absl::Status;
+using common::FontHelper;
+using ift::proto::PerTablePatch;
+using patch_subset::FontData;
+
+namespace ift {
+
+Status PerTableBrotliBinaryDiff::Diff(const FontData& font_base,
+                                      const FontData& font_derived,
+                                      FontData* patch /* OUT */) const {
+  hb_face_t* face_base = font_base.reference_face();
+  hb_face_t* face_derived = font_derived.reference_face();
+
+  auto base_tags = FontHelper::GetTags(face_base);
+  auto derived_tags = FontHelper::GetTags(face_derived);
+  auto diff_tags = TagsToDiff(base_tags, derived_tags);
+
+  PerTablePatch patch_proto;
+
+  for (std::string tag : diff_tags) {
+    hb_tag_t t = HB_TAG(tag[0], tag[1], tag[2], tag[3]);
+    bool in_base = base_tags.contains(t);
+    bool in_derived = derived_tags.contains(t);
+
+    if (in_base && !in_derived) {
+      patch_proto.add_removed_tables(tag);
+      continue;
+    }
+
+    FontData base_table = FontHelper::TableData(face_base, t);
+    FontData derived_table = FontHelper::TableData(face_derived, t);
+    FontData table_patch;
+    auto sc = binary_diff_.Diff(base_table, derived_table, &table_patch);
+    if (!sc.ok()) {
+      hb_face_destroy(face_base);
+      hb_face_destroy(face_derived);
+      return sc;
+    }
+
+    (*patch_proto.mutable_table_patches())[tag] = table_patch.str();
+  }
+
+  hb_face_destroy(face_base);
+  hb_face_destroy(face_derived);
+
+  std::string patch_data = patch_proto.SerializeAsString();
+  patch->copy(patch_data);
+
+  return absl::OkStatus();
+}
+
+void PerTableBrotliBinaryDiff::AddAllMatching(
+    const flat_hash_set<uint32_t>& tags, btree_set<std::string>& result) const {
+  for (const uint32_t& t : tags) {
+    std::string tag = FontHelper::ToString(t);
+    if (target_tags_.empty() || target_tags_.contains(tag)) {
+      result.insert(tag);
+    }
+  }
+}
+
+btree_set<std::string> PerTableBrotliBinaryDiff::TagsToDiff(
+    const absl::flat_hash_set<uint32_t>& before,
+    const absl::flat_hash_set<uint32_t>& after) const {
+  btree_set<std::string> result;
+  AddAllMatching(before, result);
+  AddAllMatching(after, result);
+  return result;
+}
+
+}  // namespace ift

--- a/ift/per_table_brotli_binary_diff.cc
+++ b/ift/per_table_brotli_binary_diff.cc
@@ -63,7 +63,7 @@ void PerTableBrotliBinaryDiff::AddAllMatching(
     const flat_hash_set<uint32_t>& tags, btree_set<std::string>& result) const {
   for (const uint32_t& t : tags) {
     std::string tag = FontHelper::ToString(t);
-    if (target_tags_.empty() || target_tags_.contains(tag)) {
+    if (!excluded_tags_.contains(tag)) {
       result.insert(tag);
     }
   }

--- a/ift/per_table_brotli_binary_diff.h
+++ b/ift/per_table_brotli_binary_diff.h
@@ -15,9 +15,9 @@ class PerTableBrotliBinaryDiff : public patch_subset::BinaryDiff {
  public:
   PerTableBrotliBinaryDiff() {}
 
-  PerTableBrotliBinaryDiff(absl::Span<const std::string> target_tags) {
-    std::copy(target_tags.begin(), target_tags.end(),
-              std::inserter(target_tags_, target_tags_.begin()));
+  PerTableBrotliBinaryDiff(absl::Span<const std::string> excluded_tags) {
+    std::copy(excluded_tags.begin(), excluded_tags.end(),
+              std::inserter(excluded_tags_, excluded_tags_.begin()));
   }
 
   absl::Status Diff(const patch_subset::FontData& font_base,
@@ -32,7 +32,7 @@ class PerTableBrotliBinaryDiff : public patch_subset::BinaryDiff {
       const absl::flat_hash_set<uint32_t>& after) const;
 
   patch_subset::BrotliBinaryDiff binary_diff_;
-  absl::btree_set<std::string> target_tags_;
+  absl::btree_set<std::string> excluded_tags_;
 };
 
 }  // namespace ift

--- a/ift/per_table_brotli_binary_diff.h
+++ b/ift/per_table_brotli_binary_diff.h
@@ -2,6 +2,7 @@
 #define IFT_PER_TABLE_BROTLI_BINARY_DIFF_H_
 
 #include <initializer_list>
+
 #include "absl/container/btree_set.h"
 #include "absl/container/flat_hash_set.h"
 #include "absl/status/status.h"
@@ -16,7 +17,8 @@ class PerTableBrotliBinaryDiff : public patch_subset::BinaryDiff {
  public:
   PerTableBrotliBinaryDiff() {}
 
-  PerTableBrotliBinaryDiff(std::initializer_list<const char*> excluded_tags) : excluded_tags_() {
+  PerTableBrotliBinaryDiff(std::initializer_list<const char*> excluded_tags)
+      : excluded_tags_() {
     std::copy(excluded_tags.begin(), excluded_tags.end(),
               std::inserter(excluded_tags_, excluded_tags_.begin()));
   }

--- a/ift/per_table_brotli_binary_diff.h
+++ b/ift/per_table_brotli_binary_diff.h
@@ -1,6 +1,7 @@
 #ifndef IFT_PER_TABLE_BROTLI_BINARY_DIFF_H_
 #define IFT_PER_TABLE_BROTLI_BINARY_DIFF_H_
 
+#include <initializer_list>
 #include "absl/container/btree_set.h"
 #include "absl/container/flat_hash_set.h"
 #include "absl/status/status.h"
@@ -15,7 +16,7 @@ class PerTableBrotliBinaryDiff : public patch_subset::BinaryDiff {
  public:
   PerTableBrotliBinaryDiff() {}
 
-  PerTableBrotliBinaryDiff(absl::Span<const std::string> excluded_tags) {
+  PerTableBrotliBinaryDiff(std::initializer_list<const char*> excluded_tags) : excluded_tags_() {
     std::copy(excluded_tags.begin(), excluded_tags.end(),
               std::inserter(excluded_tags_, excluded_tags_.begin()));
   }

--- a/ift/per_table_brotli_binary_diff.h
+++ b/ift/per_table_brotli_binary_diff.h
@@ -1,0 +1,40 @@
+#ifndef IFT_PER_TABLE_BROTLI_BINARY_DIFF_H_
+#define IFT_PER_TABLE_BROTLI_BINARY_DIFF_H_
+
+#include "absl/container/btree_set.h"
+#include "absl/container/flat_hash_set.h"
+#include "absl/status/status.h"
+#include "patch_subset/binary_diff.h"
+#include "patch_subset/brotli_binary_diff.h"
+#include "patch_subset/font_data.h"
+
+namespace ift {
+
+/* Creates a per table brotli binary diff of two fonts. */
+class PerTableBrotliBinaryDiff : public patch_subset::BinaryDiff {
+ public:
+  PerTableBrotliBinaryDiff() {}
+
+  PerTableBrotliBinaryDiff(absl::Span<const std::string> target_tags) {
+    std::copy(target_tags.begin(), target_tags.end(),
+              std::inserter(target_tags_, target_tags_.begin()));
+  }
+
+  absl::Status Diff(const patch_subset::FontData& font_base,
+                    const patch_subset::FontData& font_derived,
+                    patch_subset::FontData* patch /* OUT */) const override;
+
+ private:
+  void AddAllMatching(const absl::flat_hash_set<uint32_t>& tags,
+                      absl::btree_set<std::string>& result) const;
+  absl::btree_set<std::string> TagsToDiff(
+      const absl::flat_hash_set<uint32_t>& before,
+      const absl::flat_hash_set<uint32_t>& after) const;
+
+  patch_subset::BrotliBinaryDiff binary_diff_;
+  absl::btree_set<std::string> target_tags_;
+};
+
+}  // namespace ift
+
+#endif  // IFT_PER_TABLE_BROTLI_BINARY_DIFF_H_

--- a/ift/per_table_brotli_binary_diff_test.cc
+++ b/ift/per_table_brotli_binary_diff_test.cc
@@ -1,0 +1,200 @@
+#include "ift/per_table_brotli_binary_diff.h"
+
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "common/font_helper.h"
+#include "gtest/gtest.h"
+#include "hb.h"
+#include "ift/proto/ift_table.h"
+#include "patch_subset/brotli_binary_patch.h"
+#include "patch_subset/font_data.h"
+
+using absl::StatusOr;
+using absl::string_view;
+using common::FontHelper;
+using ift::proto::PerTablePatch;
+using patch_subset::BrotliBinaryPatch;
+using patch_subset::FontData;
+
+namespace ift {
+
+class PerTableBrotliBinaryDiffTest : public ::testing::Test {
+ protected:
+  PerTableBrotliBinaryDiffTest() {
+    // TODO
+  }
+
+  hb_tag_t tag1 = HB_TAG('t', 'a', 'g', '1');
+  hb_tag_t tag2 = HB_TAG('t', 'a', 'g', '2');
+  hb_tag_t tag3 = HB_TAG('t', 'a', 'g', '3');
+
+  std::string tag1_str = FontHelper::ToString(tag1);
+  std::string tag2_str = FontHelper::ToString(tag2);
+  std::string tag3_str = FontHelper::ToString(tag3);
+};
+
+StatusOr<std::string> patch_table(std::string before, std::string table_patch) {
+  FontData base, patch;
+  base.copy(before.data(), before.size());
+  patch.copy(table_patch.data(), table_patch.size());
+
+  FontData derived;
+  BrotliBinaryPatch patcher;
+  auto sc = patcher.Patch(base, patch, &derived);
+  if (!sc.ok()) {
+    return sc;
+  }
+
+  return derived.string();
+}
+
+TEST_F(PerTableBrotliBinaryDiffTest, BasicDiff) {
+  FontData before = FontHelper::BuildFont({
+      {tag1, "foo"},
+      {tag2, "bar"},
+  });
+
+  FontData after = FontHelper::BuildFont({
+      {tag1, "fooo"},
+      {tag2, "baar"},
+  });
+
+  PerTableBrotliBinaryDiff differ;
+  FontData patch;
+  auto sc = differ.Diff(before, after, &patch);
+  ASSERT_TRUE(sc.ok()) << sc;
+
+  PerTablePatch patch_proto;
+  ASSERT_TRUE(patch_proto.ParseFromArray(patch.data(), patch.size()));
+  ASSERT_TRUE(patch_proto.removed_tables().empty());
+
+  ASSERT_EQ(patch_proto.table_patches_size(), 2);
+
+  auto new_table = patch_table("foo", patch_proto.table_patches().at(tag1_str));
+  ASSERT_TRUE(new_table.ok()) << new_table.status();
+  ASSERT_EQ(*new_table, "fooo");
+
+  new_table = patch_table("bar", patch_proto.table_patches().at(tag2_str));
+  ASSERT_TRUE(new_table.ok()) << new_table.status();
+  ASSERT_EQ(*new_table, "baar");
+}
+
+TEST_F(PerTableBrotliBinaryDiffTest, RemoveTable) {
+  FontData before = FontHelper::BuildFont({
+      {tag1, "foo"},
+      {tag2, "bar"},
+  });
+
+  FontData after = FontHelper::BuildFont({
+      {tag1, "foo"},
+  });
+
+  PerTableBrotliBinaryDiff differ;
+  FontData patch;
+  auto sc = differ.Diff(before, after, &patch);
+  ASSERT_TRUE(sc.ok()) << sc;
+
+  PerTablePatch patch_proto;
+  ASSERT_TRUE(patch_proto.ParseFromArray(patch.data(), patch.size()));
+  ASSERT_EQ(patch_proto.removed_tables().size(), 1);
+  ASSERT_EQ(patch_proto.table_patches_size(), 1);
+
+  ASSERT_EQ(patch_proto.removed_tables().at(0), tag2_str);
+
+  auto new_table = patch_table("foo", patch_proto.table_patches().at(tag1_str));
+  ASSERT_TRUE(new_table.ok()) << new_table.status();
+  ASSERT_EQ(*new_table, "foo");
+}
+
+TEST_F(PerTableBrotliBinaryDiffTest, AddTable) {
+  FontData before = FontHelper::BuildFont({
+      {tag1, "foo"},
+  });
+
+  FontData after = FontHelper::BuildFont({
+      {tag1, "foo"},
+      {tag2, "bar"},
+  });
+
+  PerTableBrotliBinaryDiff differ;
+  FontData patch;
+  auto sc = differ.Diff(before, after, &patch);
+  ASSERT_TRUE(sc.ok()) << sc;
+
+  PerTablePatch patch_proto;
+  ASSERT_TRUE(patch_proto.ParseFromArray(patch.data(), patch.size()));
+  ASSERT_TRUE(patch_proto.removed_tables().empty());
+
+  ASSERT_EQ(patch_proto.table_patches_size(), 2);
+
+  auto new_table = patch_table("foo", patch_proto.table_patches().at(tag1_str));
+  ASSERT_TRUE(new_table.ok()) << new_table.status();
+  ASSERT_EQ(*new_table, "foo");
+
+  new_table = patch_table("", patch_proto.table_patches().at(tag2_str));
+  ASSERT_TRUE(new_table.ok()) << new_table.status();
+  ASSERT_EQ(*new_table, "bar");
+}
+
+TEST_F(PerTableBrotliBinaryDiffTest, FilteredDiff) {
+  FontData before = FontHelper::BuildFont({
+      {tag1, "foo"},
+      {tag2, "bar"},
+      {tag3, "baz"},
+  });
+
+  FontData after = FontHelper::BuildFont({
+      {tag1, "fooo"},
+      {tag2, "baar"},
+      {tag3, "baaz"},
+  });
+
+  PerTableBrotliBinaryDiff differ({tag1_str, tag3_str});
+  FontData patch;
+  auto sc = differ.Diff(before, after, &patch);
+  ASSERT_TRUE(sc.ok()) << sc;
+
+  PerTablePatch patch_proto;
+  ASSERT_TRUE(patch_proto.ParseFromArray(patch.data(), patch.size()));
+  ASSERT_TRUE(patch_proto.removed_tables().empty());
+
+  ASSERT_EQ(patch_proto.table_patches_size(), 2);
+
+  auto new_table = patch_table("foo", patch_proto.table_patches().at(tag1_str));
+  ASSERT_TRUE(new_table.ok()) << new_table.status();
+  ASSERT_EQ(*new_table, "fooo");
+
+  new_table = patch_table("baz", patch_proto.table_patches().at(tag3_str));
+  ASSERT_TRUE(new_table.ok()) << new_table.status();
+  ASSERT_EQ(*new_table, "baaz");
+}
+
+TEST_F(PerTableBrotliBinaryDiffTest, FilteredDiff_WithRemove) {
+  FontData before = FontHelper::BuildFont({
+      {tag1, "foo"},
+      {tag2, "bar"},
+      {tag3, "baz"},
+  });
+
+  FontData after = FontHelper::BuildFont({
+      {tag1, "fooo"},
+  });
+
+  PerTableBrotliBinaryDiff differ({tag1_str, tag3_str});
+  FontData patch;
+  auto sc = differ.Diff(before, after, &patch);
+  ASSERT_TRUE(sc.ok()) << sc;
+
+  PerTablePatch patch_proto;
+  ASSERT_TRUE(patch_proto.ParseFromArray(patch.data(), patch.size()));
+  ASSERT_EQ(patch_proto.removed_tables().size(), 1);
+  ASSERT_EQ(patch_proto.table_patches_size(), 1);
+
+  ASSERT_EQ(patch_proto.removed_tables().at(0), tag3_str);
+
+  auto new_table = patch_table("foo", patch_proto.table_patches().at(tag1_str));
+  ASSERT_TRUE(new_table.ok()) << new_table.status();
+  ASSERT_EQ(*new_table, "fooo");
+}
+
+}  // namespace ift

--- a/ift/per_table_brotli_binary_diff_test.cc
+++ b/ift/per_table_brotli_binary_diff_test.cc
@@ -149,7 +149,7 @@ TEST_F(PerTableBrotliBinaryDiffTest, FilteredDiff) {
       {tag3, "baaz"},
   });
 
-  PerTableBrotliBinaryDiff differ({tag1_str, tag3_str});
+  PerTableBrotliBinaryDiff differ({tag2_str});
   FontData patch;
   auto sc = differ.Diff(before, after, &patch);
   ASSERT_TRUE(sc.ok()) << sc;
@@ -180,7 +180,7 @@ TEST_F(PerTableBrotliBinaryDiffTest, FilteredDiff_WithRemove) {
       {tag1, "fooo"},
   });
 
-  PerTableBrotliBinaryDiff differ({tag1_str, tag3_str});
+  PerTableBrotliBinaryDiff differ({tag2_str});
   FontData patch;
   auto sc = differ.Diff(before, after, &patch);
   ASSERT_TRUE(sc.ok()) << sc;

--- a/ift/per_table_brotli_binary_diff_test.cc
+++ b/ift/per_table_brotli_binary_diff_test.cc
@@ -149,7 +149,7 @@ TEST_F(PerTableBrotliBinaryDiffTest, FilteredDiff) {
       {tag3, "baaz"},
   });
 
-  PerTableBrotliBinaryDiff differ({tag2_str});
+  PerTableBrotliBinaryDiff differ({tag2_str.c_str()});
   FontData patch;
   auto sc = differ.Diff(before, after, &patch);
   ASSERT_TRUE(sc.ok()) << sc;
@@ -180,7 +180,7 @@ TEST_F(PerTableBrotliBinaryDiffTest, FilteredDiff_WithRemove) {
       {tag1, "fooo"},
   });
 
-  PerTableBrotliBinaryDiff differ({tag2_str});
+  PerTableBrotliBinaryDiff differ({tag2_str.c_str()});
   FontData patch;
   auto sc = differ.Diff(before, after, &patch);
   ASSERT_TRUE(sc.ok()) << sc;

--- a/ift/per_table_brotli_binary_patch.cc
+++ b/ift/per_table_brotli_binary_patch.cc
@@ -1,0 +1,82 @@
+#include "ift/per_table_brotli_binary_patch.h"
+
+#include "common/font_helper.h"
+#include "hb.h"
+#include "ift/proto/IFT.pb.h"
+#include "patch_subset/font_data.h"
+
+using absl::Status;
+using common::FontHelper;
+using ift::proto::PerTablePatch;
+using patch_subset::FontData;
+
+namespace ift {
+
+Status PerTableBrotliBinaryPatch::Patch(const FontData& font_base,
+                                        const FontData& patch,
+                                        FontData* font_derived) const {
+  PerTablePatch proto;
+  if (!proto.ParseFromArray(patch.data(), patch.size())) {
+    return absl::InternalError("Failed to decode patch protobuf.");
+  }
+
+  hb_face_t* base = font_base.reference_face();
+  auto tags = FontHelper::GetTags(base);
+
+  // Some tags might be new so add all tags in the patch's table list.
+  for (const auto& e : proto.table_patches()) {
+    const std::string& tag = e.first;
+    tags.insert(HB_TAG(tag[0], tag[1], tag[2], tag[3]));
+  }
+
+  // Remove any tags that are marked for removal.
+  for (std::string tag : proto.removed_tables()) {
+    tags.erase(HB_TAG(tag[0], tag[1], tag[2], tag[3]));
+  }
+
+  hb_face_t* new_face = hb_face_builder_create();
+  for (hb_tag_t t : tags) {
+    FontData data = FontHelper::TableData(base, t);
+    FontData patch;
+
+    std::string tag = FontHelper::ToString(t);
+    const std::string& patch_data = proto.table_patches().at(tag);
+    patch.copy(patch_data.data(), patch.size());
+
+    FontData derived;
+    auto sc = binary_patch_.Patch(data, patch, &derived);
+    if (!sc.ok()) {
+      hb_face_destroy(base);
+      hb_face_destroy(new_face);
+      return sc;
+    }
+
+    hb_blob_t* blob = derived.reference_blob();
+    hb_face_builder_add_table(new_face, t, blob);
+    hb_blob_destroy(blob);
+  }
+
+  hb_blob_t* new_face_blob = hb_face_reference_blob(new_face);
+  font_derived->set(new_face_blob);
+  hb_blob_destroy(new_face_blob);
+  hb_face_destroy(base);
+
+  return absl::OkStatus();
+}
+
+Status PerTableBrotliBinaryPatch::Patch(const FontData& font_base,
+                                        const std::vector<FontData>& patch,
+                                        FontData* font_derived) const {
+  if (patch.size() == 1) {
+    return Patch(font_base, patch[0], font_derived);
+  }
+
+  if (patch.size() == 0) {
+    return absl::InvalidArgumentError("Must provide at least one patch.");
+  }
+
+  return absl::InvalidArgumentError(
+      "Per table brotli binary patches cannot be applied independently.");
+}
+
+}  // namespace ift

--- a/ift/per_table_brotli_binary_patch.cc
+++ b/ift/per_table_brotli_binary_patch.cc
@@ -62,6 +62,8 @@ Status PerTableBrotliBinaryPatch::Patch(const FontData& font_base,
     hb_blob_destroy(blob);
   }
 
+  FontHelper::ApplyIftbTableOrdering(new_face);
+
   hb_blob_t* new_face_blob = hb_face_reference_blob(new_face);
   font_derived->set(new_face_blob);
   hb_blob_destroy(new_face_blob);

--- a/ift/per_table_brotli_binary_patch.h
+++ b/ift/per_table_brotli_binary_patch.h
@@ -1,0 +1,32 @@
+#ifndef IFT_PER_TABLE_BROTLI_BINARY_PATCH_H_
+#define IFT_PER_TABLE_BROTLI_BINARY_PATCH_H_
+
+#include "absl/status/status.h"
+#include "patch_subset/binary_patch.h"
+#include "patch_subset/brotli_binary_patch.h"
+#include "patch_subset/font_data.h"
+
+namespace ift {
+
+/* Creates a per table brotli binary diff of two fonts. */
+class PerTableBrotliBinaryPatch : public patch_subset::BinaryPatch {
+ public:
+  PerTableBrotliBinaryPatch() {}
+
+  absl::Status Patch(const patch_subset::FontData& font_base,
+                     const patch_subset::FontData& patch,
+                     patch_subset::FontData* font_derived) const override;
+
+  // Apply a set of independent patches to font_base and write the results to
+  // font_derived. will fail if the underlying patch is dependent.
+  absl::Status Patch(const patch_subset::FontData& font_base,
+                     const std::vector<patch_subset::FontData>& patch,
+                     patch_subset::FontData* font_derived) const override;
+
+ private:
+  patch_subset::BrotliBinaryPatch binary_patch_;
+};
+
+}  // namespace ift
+
+#endif  // IFT_PER_TABLE_BROTLI_BINARY_PATCH_H_

--- a/ift/per_table_brotli_binary_patch_test.cc
+++ b/ift/per_table_brotli_binary_patch_test.cc
@@ -1,0 +1,78 @@
+#include "ift/per_table_brotli_binary_patch.h"
+
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "common/font_helper.h"
+#include "gtest/gtest.h"
+#include "hb.h"
+#include "ift/proto/IFT.pb.h"
+#include "patch_subset/brotli_binary_diff.h"
+#include "patch_subset/brotli_binary_patch.h"
+#include "patch_subset/font_data.h"
+
+using absl::StatusOr;
+using absl::string_view;
+using common::FontHelper;
+using ift::proto::PerTablePatch;
+using patch_subset::BrotliBinaryDiff;
+using patch_subset::BrotliBinaryPatch;
+using patch_subset::FontData;
+
+namespace ift {
+
+class PerTableBrotliBinaryPatchTest : public ::testing::Test {
+ protected:
+  PerTableBrotliBinaryPatchTest() {
+    BrotliBinaryDiff differ;
+
+    FontData foo, bar, abc, def;
+    foo.copy("foo");
+    bar.copy("bar");
+    abc.copy("abc");
+    def.copy("def");
+
+    assert(differ.Diff(foo, bar, &foo_to_bar).ok());
+    assert(differ.Diff(abc, def, &abc_to_def).ok());
+  }
+
+  hb_tag_t tag1 = HB_TAG('t', 'a', 'g', '1');
+  hb_tag_t tag2 = HB_TAG('t', 'a', 'g', '2');
+  hb_tag_t tag3 = HB_TAG('t', 'a', 'g', '3');
+
+  std::string tag1_str = FontHelper::ToString(tag1);
+  std::string tag2_str = FontHelper::ToString(tag2);
+  std::string tag3_str = FontHelper::ToString(tag3);
+
+  FontData foo_to_bar;
+  FontData abc_to_def;
+
+  PerTableBrotliBinaryPatch patcher;
+};
+
+TEST_F(PerTableBrotliBinaryPatchTest, BasicPatch) {
+  FontData before = FontHelper::BuildFont({
+      {tag1, "foo"},
+      {tag2, "abc"},
+  });
+  FontData after = FontHelper::BuildFont({
+      {tag1, "bar"},
+      {tag2, "def"},
+  });
+
+  PerTablePatch patch_proto;
+  (*patch_proto.mutable_table_patches())[tag1_str] = foo_to_bar.string();
+  (*patch_proto.mutable_table_patches())[tag2_str] = abc_to_def.string();
+  std::string patch = patch_proto.SerializeAsString();
+  FontData patch_data;
+  patch_data.copy(patch.data(), patch.size());
+
+  FontData result;
+  auto sc = patcher.Patch(before, patch_data, &result);
+  ASSERT_TRUE(sc.ok()) << sc;
+
+  ASSERT_EQ(after.str(), result.str());
+}
+
+// TODO test more advanced cases.
+
+}  // namespace ift

--- a/ift/proto/BUILD
+++ b/ift/proto/BUILD
@@ -5,6 +5,8 @@ cc_library(
   srcs = [
     "ift_table.h",
     "ift_table.cc",
+    "patch_map.h",
+    "patch_map.cc",
   ],
   visibility = [
     "//util:__pkg__",
@@ -27,7 +29,7 @@ cc_test(
     name = "ift_table_test",
     size = "small",
     srcs = [
-        "ift_table_test.cc",
+        "ift_table_test.cc",    
     ],
     data = [
         "//patch_subset:testdata",
@@ -39,6 +41,27 @@ cc_test(
         "//common",
         "@gtest//:gtest_main",
         "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/container:flat_hash_set",
+    ],
+)
+
+cc_test(
+    name = "patch_map_test",
+    size = "small",
+    srcs = [
+        "patch_map_test.cc",
+    ],
+    data = [
+        "//patch_subset:testdata",
+        "//ift:testdata",
+    ],
+    deps = [
+        ":proto",
+        ":IFT_cc_proto",
+        "//common",
+        "@gtest//:gtest_main",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/container:btree",
         "@com_google_absl//absl/container:flat_hash_set",
     ],
 )

--- a/ift/proto/IFT.proto
+++ b/ift/proto/IFT.proto
@@ -11,9 +11,10 @@ enum PatchEncoding {
   // Shared brotli patches are dependent.
   SHARED_BROTLI_ENCODING = 2;
 
-  // TODO(garretrieger): add a per table shared brotli encoding.
+  // Per table shared brotli patches are dependent.
+  PER_TABLE_SHARED_BROTLI_ENCODING = 3;
 
-  // next = 3
+  // next = 4
 }
 
 message IFT {
@@ -56,4 +57,13 @@ message SubsetMapping {
   PatchEncoding patch_encoding = 4;
 
   // next = 6
+}
+
+// Format for a table-wise shared brotli patch.
+message PerTablePatch {
+  repeated uint32 id = 1;
+  map<string, bytes> table_patches = 2;
+  repeated string removed_tables = 3;
+
+  // next = 4
 }

--- a/ift/proto/IFT.proto
+++ b/ift/proto/IFT.proto
@@ -4,8 +4,15 @@ package ift.proto;
 
 enum PatchEncoding {
   DEFAULT_ENCODING = 0;
+
+  // IFTB patches are independent.
   IFTB_ENCODING = 1;
+
+  // Shared brotli patches are dependent.
   SHARED_BROTLI_ENCODING = 2;
+
+  // TODO(garretrieger): add a per table shared brotli encoding.
+
   // next = 3
 }
 
@@ -19,9 +26,8 @@ message IFT {
   PatchEncoding default_patch_encoding = 3;
 
   repeated SubsetMapping subset_mapping = 4;
-  repeated CombinedSubsetMapping combined_subset_mapping = 5;
-
-  // next = 6
+  
+  // next = 5
 }
 
 // Maps from a subset description to a patch
@@ -34,31 +40,20 @@ message SubsetMapping {
   // The encoded bytes of a SparseBitSet (see: patch_subset/sparse_bit_set.h)
   bytes codepoint_set = 2;
 
-  // TODO(garretrieger): add layout features and design space.
+  // List of features encoded using known ids, or the 4 byte tag as a uint32.
+  uint32 features = 5;
+
+  // Re-use previously defined subset definitions, must have indices less than the index
+  // for this entry (ensures no cycles). Any referenced definitions are unioned into this
+  // one.
+  repeated uint32 subset_indices = 6;
+
+  // TODO(garretrieger): add design space.
 
   // == VALUE ==
 
   int32 id_delta = 3;
   PatchEncoding patch_encoding = 4;
 
-  // next = 5
-}
-
-// Maps from a subset description (formed as a union of previously listed definitions)
-// to a patch
-//
-// TODO(garretrieger): should this just be an optional field in the SubsetMapping object above?
-message CombinedSubsetMapping {
-  // == KEY == 
-
-  // TODO(garretrieger): Use bias + sparse bit sets here?
-  repeated uint32 subset_indices = 1;
-
-  // TODO(garretrieger): support adding features here
-
-  // == VALUE ==
-  uint32 id = 2;
-  PatchEncoding patch_encoding = 3;
-
-  // next = 4
+  // next = 6
 }

--- a/ift/proto/ift_table.cc
+++ b/ift/proto/ift_table.cc
@@ -157,10 +157,10 @@ StatusOr<FontData> IFTTable::AddToFont(hb_face_t* face, const IFT& proto,
 StatusOr<FontData> IFTTable::AddToFont(hb_face_t* face) {
   IFT proto;
   proto.set_url_template(url_template_);
-  proto.set_id(0, id_[0]);
-  proto.set_id(1, id_[1]);
-  proto.set_id(2, id_[2]);
-  proto.set_id(3, id_[3]);
+  proto.add_id(id_[0]);
+  proto.add_id(id_[1]);
+  proto.add_id(id_[2]);
+  proto.add_id(id_[3]);
   proto.set_default_patch_encoding(default_encoding_);
   patch_map_.AddToProto(proto);
   return AddToFont(face, proto);

--- a/ift/proto/ift_table.cc
+++ b/ift/proto/ift_table.cc
@@ -58,7 +58,7 @@ StatusOr<IFTTable> IFTTable::FromFont(hb_face_t* face) {
   data_string = ift_table.string();
   ift_proto.Clear();
   if (!ift_proto.ParseFromString(data_string)) {
-    return absl::InternalError("Unable to parse 'IFT ' table.");
+    return absl::InternalError("Unable to parse 'IFTX' table.");
   }
 
   auto s = ift->GetPatchMap().AddFromProto(ift_proto, true);
@@ -189,7 +189,7 @@ StatusOr<FontData> IFTTable::AddToFont(hb_face_t* face, const IFT& proto,
   return new_font_data;
 }
 
-StatusOr<FontData> IFTTable::AddToFont(hb_face_t* face) {
+IFT IFTTable::CreateMainTable() {
   IFT proto;
   proto.set_url_template(url_template_);
   proto.add_id(id_[0]);
@@ -198,14 +198,15 @@ StatusOr<FontData> IFTTable::AddToFont(hb_face_t* face) {
   proto.add_id(id_[3]);
   proto.set_default_patch_encoding(default_encoding_);
   patch_map_.AddToProto(proto);
+  return proto;
+}
 
-  bool has_extension_entries = HasExtensionEntries();
+IFT IFTTable::CreateExtensionTable() {
   IFT ext_proto;
-  if (has_extension_entries) {
+  if (HasExtensionEntries()) {
     patch_map_.AddToProto(ext_proto, true);
   }
-
-  return AddToFont(face, proto, has_extension_entries ? &ext_proto : nullptr);
+  return ext_proto;
 }
 
 void IFTTable::GetId(uint32_t out[4]) const {

--- a/ift/proto/ift_table.h
+++ b/ift/proto/ift_table.h
@@ -54,9 +54,16 @@ class IFTTable {
   const std::string& GetUrlTemplate() const { return url_template_; }
 
   /*
-   * Adds a copy of this table to the supplied 'face'.
+   * Converts this abstract representation to the proto representation.
+   * This method generates the proto for the main "IFT " table.
    */
-  absl::StatusOr<patch_subset::FontData> AddToFont(hb_face_t* face);
+  IFT CreateMainTable();
+
+  /*
+   * Converts this abstract representation to the proto representation.
+   * This method generates the proto for the extension "IFTX" table.
+   */
+  IFT CreateExtensionTable();
 
  private:
   std::string url_template_;

--- a/ift/proto/ift_table.h
+++ b/ift/proto/ift_table.h
@@ -42,12 +42,14 @@ class IFTTable {
    * according to IFTB ordering requirements.
    */
   static absl::StatusOr<patch_subset::FontData> AddToFont(
-      hb_face_t* face, const IFT& proto, bool iftb_conversion = false);
+      hb_face_t* face, const IFT& proto, const IFT* extension_proto = nullptr,
+      bool iftb_conversion = false);
 
   void GetId(uint32_t out[4]) const;
 
   const PatchMap& GetPatchMap() const { return patch_map_; }
   PatchMap& GetPatchMap() { return patch_map_; }
+  bool HasExtensionEntries() const;
 
   const std::string& GetUrlTemplate() const { return url_template_; }
 

--- a/ift/proto/ift_table.h
+++ b/ift/proto/ift_table.h
@@ -47,6 +47,7 @@ class IFTTable {
   void GetId(uint32_t out[4]) const;
 
   const PatchMap& GetPatchMap() const { return patch_map_; }
+  PatchMap& GetPatchMap() { return patch_map_; }
 
   const std::string& GetUrlTemplate() const { return url_template_; }
 

--- a/ift/proto/ift_table_test.cc
+++ b/ift/proto/ift_table_test.cc
@@ -186,7 +186,9 @@ TEST_F(IFTTableTest, RoundTrip_WithExtension) {
   table.GetPatchMap().AddEntry({30}, 3, SHARED_BROTLI_ENCODING, true);
   table.GetPatchMap().AddEntry({40}, 4, SHARED_BROTLI_ENCODING, true);
 
-  auto font = table.AddToFont(roboto_ab);
+  IFT main = table.CreateMainTable();
+  IFT ext = table.CreateExtensionTable();
+  auto font = IFTTable::AddToFont(roboto_ab, main, &ext);
   ASSERT_TRUE(font.ok()) << font.status();
 
   auto table_from_font = IFTTable::FromFont(*font);

--- a/ift/proto/ift_table_test.cc
+++ b/ift/proto/ift_table_test.cc
@@ -206,7 +206,7 @@ TEST_F(IFTTableTest, HasExtensionEntries) {
   table.GetPatchMap().AddEntry({10}, 1, SHARED_BROTLI_ENCODING);
   table.GetPatchMap().AddEntry({20}, 2, SHARED_BROTLI_ENCODING);
   ASSERT_FALSE(table.HasExtensionEntries());
-  
+
   table.GetPatchMap().AddEntry({30}, 3, SHARED_BROTLI_ENCODING, true);
   ASSERT_TRUE(table.HasExtensionEntries());
 }

--- a/ift/proto/patch_map.cc
+++ b/ift/proto/patch_map.cc
@@ -1,0 +1,131 @@
+#include "ift/proto/patch_map.h"
+
+#include "absl/container/btree_set.h"
+#include "absl/container/flat_hash_set.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_format.h"
+#include "absl/types/span.h"
+#include "ift/proto/IFT.pb.h"
+#include "patch_subset/hb_set_unique_ptr.h"
+#include "patch_subset/sparse_bit_set.h"
+
+using absl::Span;
+using absl::StatusOr;
+using patch_subset::hb_set_unique_ptr;
+using patch_subset::make_hb_set;
+using patch_subset::SparseBitSet;
+
+namespace ift::proto {
+
+StatusOr<PatchMap::Coverage> PatchMap::Coverage::FromProto(
+    const ift::proto::SubsetMapping& mapping) {
+  uint32_t bias = mapping.bias();
+  hb_set_unique_ptr codepoints = make_hb_set();
+  auto s = SparseBitSet::Decode(mapping.codepoint_set(), codepoints.get());
+  if (!s.ok()) {
+    return s;
+  }
+
+  Coverage coverage;
+  hb_codepoint_t cp = HB_SET_VALUE_INVALID;
+  while (hb_set_next(codepoints.get(), &cp)) {
+    uint32_t actual_cp = cp + bias;
+    coverage.codepoints.insert(actual_cp);
+  }
+
+  return coverage;
+}
+
+StatusOr<PatchMap::Entry> PatchMap::Entry::FromProto(
+    const ift::proto::SubsetMapping& mapping, uint32_t index,
+    PatchEncoding enc) {
+  auto c = Coverage::FromProto(mapping);
+  if (!c.ok()) {
+    return c.status();
+  }
+
+  Entry entry;
+  entry.coverage = std::move(*c);
+  entry.encoding = enc;
+  entry.patch_index = index;
+  return entry;
+}
+
+StatusOr<PatchMap> PatchMap::FromProto(const IFT& ift_proto) {
+  PatchMap map;
+
+  PatchEncoding default_encoding = ift_proto.default_patch_encoding();
+  int32_t id = 0;
+  for (const auto& m : ift_proto.subset_mapping()) {
+    id += m.id_delta() + 1;
+    uint32_t patch_idx = id;
+    PatchEncoding encoding = m.patch_encoding();
+    if (encoding == DEFAULT_ENCODING) {
+      encoding = default_encoding;
+    }
+
+    auto e = Entry::FromProto(m, patch_idx, encoding);
+    if (!e.ok()) {
+      return e.status();
+    }
+
+    map.entries_.push_back(std::move(*e));
+  }
+
+  return map;
+}
+
+void PrintTo(const PatchMap::Coverage& coverage, std::ostream* os) {
+  absl::btree_set<uint32_t> sorted_codepoints;
+  std::copy(coverage.codepoints.begin(), coverage.codepoints.end(),
+            std::inserter(sorted_codepoints, sorted_codepoints.begin()));
+
+  *os << "{";
+  for (auto it = sorted_codepoints.begin(); it != sorted_codepoints.end();
+       it++) {
+    *os << *it;
+    auto next = it;
+    if (++next != sorted_codepoints.end()) {
+      *os << ", ";
+    }
+  }
+  *os << "}";
+}
+
+void PrintTo(const PatchMap::Entry& entry, std::ostream* os) {
+  PrintTo(entry.coverage, os);
+  *os << ", " << entry.patch_index << ", " << entry.encoding;
+}
+
+void PrintTo(const PatchMap& map, std::ostream* os) {
+  *os << "[" << std::endl;
+  for (const auto& e : map.entries_) {
+    *os << "  {";
+    PrintTo(e, os);
+    *os << "}," << std::endl;
+  }
+  *os << "]";
+}
+
+Span<const PatchMap::Entry> PatchMap::GetEntries() const { return entries_; }
+
+void PatchMap::AddEntry(const PatchMap::Coverage& coverage,
+                        uint32_t patch_index, PatchEncoding encoding) {
+  Entry e;
+  e.coverage = coverage;
+  e.patch_index = patch_index;
+  e.encoding = encoding;
+  entries_.push_back(std::move(e));
+}
+
+void PatchMap::RemoveEntries(uint32_t patch_index) {
+  for (auto it = entries_.begin(); it != entries_.end();) {
+    if (it->patch_index == patch_index) {
+      entries_.erase(it);
+      continue;
+    }
+    ++it;
+  }
+}
+
+}  // namespace ift::proto

--- a/ift/proto/patch_map.cc
+++ b/ift/proto/patch_map.cc
@@ -179,14 +179,32 @@ void PatchMap::AddEntry(const PatchMap::Coverage& coverage,
   entries_.push_back(std::move(e));
 }
 
-void PatchMap::RemoveEntries(uint32_t patch_index) {
+PatchMap::Modification PatchMap::RemoveEntries(uint32_t patch_index) {
+  bool modified_ext = false;
+  bool modified_main = false;
   for (auto it = entries_.begin(); it != entries_.end();) {
     if (it->patch_index == patch_index) {
+      modified_main = modified_main || !it->extension_entry;
+      modified_ext = modified_ext || it->extension_entry;
       entries_.erase(it);
       continue;
     }
     ++it;
   }
+
+  if (modified_ext && modified_main) {
+    return MODIFIED_BOTH;
+  }
+
+  if (modified_ext) {
+    return MODIFIED_EXTENSION;
+  }
+
+  if (modified_main) {
+    return MODIFIED_MAIN;
+  }
+
+  return MODIFIED_NEITHER;
 }
 
 }  // namespace ift::proto

--- a/ift/proto/patch_map.cc
+++ b/ift/proto/patch_map.cc
@@ -117,10 +117,14 @@ Status PatchMap::AddFromProto(const IFT& ift_proto, bool is_extension_table) {
   return absl::OkStatus();
 }
 
-void PatchMap::AddToProto(IFT& ift_proto) const {
+void PatchMap::AddToProto(IFT& ift_proto, bool extension_entries) const {
   PatchEncoding default_encoding = ift_proto.default_patch_encoding();
   uint32_t last_patch_index = 0;
   for (const Entry& e : entries_) {
+    if (e.extension_entry != extension_entries) {
+      continue;
+    }
+
     auto* m = ift_proto.add_subset_mapping();
     e.ToProto(last_patch_index, default_encoding, m);
     last_patch_index = e.patch_index;

--- a/ift/proto/patch_map.cc
+++ b/ift/proto/patch_map.cc
@@ -151,6 +151,9 @@ void PrintTo(const PatchMap::Coverage& coverage, std::ostream* os) {
 void PrintTo(const PatchMap::Entry& entry, std::ostream* os) {
   PrintTo(entry.coverage, os);
   *os << ", " << entry.patch_index << ", " << entry.encoding;
+  if (entry.extension_entry) {
+    *os << ", ext";
+  }
 }
 
 void PrintTo(const PatchMap& map, std::ostream* os) {
@@ -166,11 +169,13 @@ void PrintTo(const PatchMap& map, std::ostream* os) {
 Span<const PatchMap::Entry> PatchMap::GetEntries() const { return entries_; }
 
 void PatchMap::AddEntry(const PatchMap::Coverage& coverage,
-                        uint32_t patch_index, PatchEncoding encoding) {
+                        uint32_t patch_index, PatchEncoding encoding,
+                        bool is_extension) {
   Entry e;
   e.coverage = coverage;
   e.patch_index = patch_index;
   e.encoding = encoding;
+  e.extension_entry = is_extension;
   entries_.push_back(std::move(e));
 }
 

--- a/ift/proto/patch_map.h
+++ b/ift/proto/patch_map.h
@@ -16,6 +16,11 @@ namespace ift::proto {
  */
 class PatchMap {
  public:
+  static bool IsDependent(PatchEncoding encoding) {
+    return encoding == SHARED_BROTLI_ENCODING ||
+           encoding == PER_TABLE_SHARED_BROTLI_ENCODING;
+  }
+
   struct Coverage {
     // TODO(garretrieger): move constructors?
     static absl::StatusOr<Coverage> FromProto(
@@ -66,10 +71,7 @@ class PatchMap {
                  ift::proto::PatchEncoding default_encoding,
                  ift::proto::SubsetMapping* out) const;
 
-    bool IsDependent() const {
-      return encoding == SHARED_BROTLI_ENCODING ||
-             encoding == PER_TABLE_SHARED_BROTLI_ENCODING;
-    }
+    bool IsDependent() const { return PatchMap::IsDependent(encoding); }
 
     Coverage coverage;
     uint32_t patch_index;

--- a/ift/proto/patch_map.h
+++ b/ift/proto/patch_map.h
@@ -1,0 +1,122 @@
+#ifndef IFT_PROTO_PATCH_MAP_H_
+#define IFT_PROTO_PATCH_MAP_H_
+
+#include <cstdint>
+#include <initializer_list>
+
+#include "absl/container/flat_hash_set.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_format.h"
+#include "absl/types/span.h"
+#include "ift/proto/IFT.pb.h"
+
+namespace ift::proto {
+
+/*
+ * Abstract representation of a map from subset definitions too patches.
+ */
+class PatchMap {
+  // TODO figure out what this interface should look like.
+  // - it should allow a patch selection implementation to use a gid mapped
+  // table
+  //   using direct access to the table's memory.
+  // - but also work with a implementeation where the map has been loaded into
+  // data
+  //   structures in memory.
+  //
+  // Patch selection algorithm takes a codepoint set and set of features and
+  // then returns a set of patch indices.
+  //
+  // Probably want a prefilter that selects candidate patches based on codepoint
+  // only then the selection algorithm can grab the details of each patches
+  // coverage in order to compare and make final selections.
+  //
+  // Keep in mind the differing selection algorithms for dependent vs
+  // independent.
+  //
+  // Maybe we should actually not expose this, and only have a method to produce
+  // the selections. This would have a IFTB gid map specific algorithm and then
+  // a more generic implementation which uses a in memory abstract version of
+  // the table.
+  //
+  // The in memory abstract map could then be deserialized/serialized back to
+  // either subtable type. For modification operations.
+  //
+  // So then we have:
+  // 1. Abstract patch selection algorithm:
+  //    a. Impl 1: using in memory patch map.
+  //    b. Impl 2: using IFTB gid/feature map directly.
+  // 2. In Memory Patch map, with support for modification. (THIS FILE)
+  // 3. Serialize/deserialize implementations from memory patch map to/from the
+  // protobuf
+  //    and IFTB mapping formats.
+ public:
+  struct Coverage {
+    // TODO(garretrieger): move constructors?
+    static absl::StatusOr<Coverage> FromProto(
+        const ift::proto::SubsetMapping& mapping);
+
+    Coverage() {}
+    Coverage(std::initializer_list<uint32_t> codepoints_list)
+        : codepoints(codepoints_list) {}
+
+    friend void PrintTo(const Coverage& point, std::ostream* os);
+
+    bool operator==(const Coverage& other) const {
+      return other.codepoints == codepoints && other.features == features;
+    }
+
+    absl::flat_hash_set<uint32_t> codepoints;
+    absl::flat_hash_set<uint32_t> features;
+  };
+
+  struct Entry {
+    // TODO(garretrieger): move constructors?
+    static absl::StatusOr<Entry> FromProto(
+        const ift::proto::SubsetMapping& mapping, uint32_t index,
+        ift::proto::PatchEncoding encoding);
+
+    Entry() {}
+    Entry(std::initializer_list<uint32_t> codepoints, uint32_t patch_idx,
+          PatchEncoding enc)
+        : coverage(codepoints), patch_index(patch_idx), encoding(enc) {}
+
+    friend void PrintTo(const Entry& point, std::ostream* os);
+
+    bool operator==(const Entry& other) const {
+      return other.coverage == coverage && other.patch_index == patch_index &&
+             other.encoding == encoding;
+    }
+
+    Coverage coverage;
+    uint32_t patch_index;
+    PatchEncoding encoding;
+  };
+
+  // TODO(garretrieger): move constructors?
+  PatchMap() {}
+  PatchMap(std::initializer_list<Entry> entries) : entries_(entries) {}
+
+  friend void PrintTo(const PatchMap& point, std::ostream* os);
+
+  bool operator==(const PatchMap& other) const {
+    return other.entries_ == entries_;
+  }
+
+  static absl::StatusOr<PatchMap> FromProto(const ift::proto::IFT& ift_proto);
+
+  absl::Span<const Entry> GetEntries() const;
+
+  void AddEntry(const Coverage& coverage, uint32_t patch_index,
+                ift::proto::PatchEncoding);
+  void RemoveEntries(uint32_t patch_index);
+
+ private:
+  // TODO(garretrieger): keep an index which maps from patch_index to entry
+  // index for faster deletions.
+  std::vector<Entry> entries_;
+};
+
+}  // namespace ift::proto
+
+#endif  // IFT_PROTO_PATCH_MAP_H_

--- a/ift/proto/patch_map.h
+++ b/ift/proto/patch_map.h
@@ -56,7 +56,8 @@ class PatchMap {
 
     bool operator==(const Entry& other) const {
       return other.coverage == coverage && other.patch_index == patch_index &&
-             other.encoding == encoding;
+             other.encoding == encoding &&
+             other.extension_entry == extension_entry;
     }
 
     void ToProto(uint32_t last_patch_index,
@@ -94,7 +95,7 @@ class PatchMap {
   absl::Span<const Entry> GetEntries() const;
 
   void AddEntry(const Coverage& coverage, uint32_t patch_index,
-                ift::proto::PatchEncoding);
+                ift::proto::PatchEncoding, bool is_extension = false);
   void RemoveEntries(uint32_t patch_index);
 
  private:

--- a/ift/proto/patch_map.h
+++ b/ift/proto/patch_map.h
@@ -21,6 +21,13 @@ class PatchMap {
            encoding == PER_TABLE_SHARED_BROTLI_ENCODING;
   }
 
+  enum Modification {
+    MODIFIED_NEITHER,
+    MODIFIED_MAIN,
+    MODIFIED_EXTENSION,
+    MODIFIED_BOTH,
+  };
+
   struct Coverage {
     // TODO(garretrieger): move constructors?
     static absl::StatusOr<Coverage> FromProto(
@@ -100,7 +107,8 @@ class PatchMap {
 
   void AddEntry(const Coverage& coverage, uint32_t patch_index,
                 ift::proto::PatchEncoding, bool is_extension = false);
-  void RemoveEntries(uint32_t patch_index);
+
+  Modification RemoveEntries(uint32_t patch_index);
 
  private:
   // TODO(garretrieger): keep an index which maps from patch_index to entry

--- a/ift/proto/patch_map.h
+++ b/ift/proto/patch_map.h
@@ -46,8 +46,8 @@ class PatchMap {
 
     Entry() {}
     Entry(std::initializer_list<uint32_t> codepoints, uint32_t patch_idx,
-          PatchEncoding enc)
-        : coverage(codepoints), patch_index(patch_idx), encoding(enc) {}
+          PatchEncoding enc, bool is_ext=false)
+        : coverage(codepoints), patch_index(patch_idx), encoding(enc), extension_entry(is_ext) {}
 
     friend void PrintTo(const Entry& point, std::ostream* os);
 
@@ -68,6 +68,7 @@ class PatchMap {
     Coverage coverage;
     uint32_t patch_index;
     PatchEncoding encoding;
+    bool extension_entry = false;
   };
 
   // TODO(garretrieger): move constructors?
@@ -81,6 +82,8 @@ class PatchMap {
   }
 
   static absl::StatusOr<PatchMap> FromProto(const ift::proto::IFT& ift_proto);
+  absl::Status AddFromProto(const ift::proto::IFT& ift_proto, bool is_extension_table=false);
+
   void AddToProto(ift::proto::IFT& ift_proto) const;
 
   absl::Span<const Entry> GetEntries() const;

--- a/ift/proto/patch_map.h
+++ b/ift/proto/patch_map.h
@@ -46,8 +46,11 @@ class PatchMap {
 
     Entry() {}
     Entry(std::initializer_list<uint32_t> codepoints, uint32_t patch_idx,
-          PatchEncoding enc, bool is_ext=false)
-        : coverage(codepoints), patch_index(patch_idx), encoding(enc), extension_entry(is_ext) {}
+          PatchEncoding enc, bool is_ext = false)
+        : coverage(codepoints),
+          patch_index(patch_idx),
+          encoding(enc),
+          extension_entry(is_ext) {}
 
     friend void PrintTo(const Entry& point, std::ostream* os);
 
@@ -82,9 +85,11 @@ class PatchMap {
   }
 
   static absl::StatusOr<PatchMap> FromProto(const ift::proto::IFT& ift_proto);
-  absl::Status AddFromProto(const ift::proto::IFT& ift_proto, bool is_extension_table=false);
+  absl::Status AddFromProto(const ift::proto::IFT& ift_proto,
+                            bool is_extension_table = false);
 
-  void AddToProto(ift::proto::IFT& ift_proto) const;
+  void AddToProto(ift::proto::IFT& ift_proto,
+                  bool extension_entries = false) const;
 
   absl::Span<const Entry> GetEntries() const;
 

--- a/ift/proto/patch_map.h
+++ b/ift/proto/patch_map.h
@@ -60,6 +60,8 @@ class PatchMap {
                  ift::proto::PatchEncoding default_encoding,
                  ift::proto::SubsetMapping* out) const;
 
+    bool IsDependent() const { return encoding == SHARED_BROTLI_ENCODING; }
+
     Coverage coverage;
     uint32_t patch_index;
     PatchEncoding encoding;

--- a/ift/proto/patch_map.h
+++ b/ift/proto/patch_map.h
@@ -31,6 +31,9 @@ class PatchMap {
       return other.codepoints == codepoints && other.features == features;
     }
 
+    void ToProto(ift::proto::SubsetMapping* out) const;
+
+    // TODO(garretrieger): use hb sets instead?
     absl::flat_hash_set<uint32_t> codepoints;
     absl::flat_hash_set<uint32_t> features;
   };
@@ -53,6 +56,10 @@ class PatchMap {
              other.encoding == encoding;
     }
 
+    void ToProto(uint32_t last_patch_index,
+                 ift::proto::PatchEncoding default_encoding,
+                 ift::proto::SubsetMapping* out) const;
+
     Coverage coverage;
     uint32_t patch_index;
     PatchEncoding encoding;
@@ -69,6 +76,7 @@ class PatchMap {
   }
 
   static absl::StatusOr<PatchMap> FromProto(const ift::proto::IFT& ift_proto);
+  void AddToProto(ift::proto::IFT& ift_proto) const;
 
   absl::Span<const Entry> GetEntries() const;
 

--- a/ift/proto/patch_map.h
+++ b/ift/proto/patch_map.h
@@ -6,7 +6,6 @@
 
 #include "absl/container/flat_hash_set.h"
 #include "absl/status/statusor.h"
-#include "absl/strings/str_format.h"
 #include "absl/types/span.h"
 #include "ift/proto/IFT.pb.h"
 
@@ -16,40 +15,6 @@ namespace ift::proto {
  * Abstract representation of a map from subset definitions too patches.
  */
 class PatchMap {
-  // TODO figure out what this interface should look like.
-  // - it should allow a patch selection implementation to use a gid mapped
-  // table
-  //   using direct access to the table's memory.
-  // - but also work with a implementeation where the map has been loaded into
-  // data
-  //   structures in memory.
-  //
-  // Patch selection algorithm takes a codepoint set and set of features and
-  // then returns a set of patch indices.
-  //
-  // Probably want a prefilter that selects candidate patches based on codepoint
-  // only then the selection algorithm can grab the details of each patches
-  // coverage in order to compare and make final selections.
-  //
-  // Keep in mind the differing selection algorithms for dependent vs
-  // independent.
-  //
-  // Maybe we should actually not expose this, and only have a method to produce
-  // the selections. This would have a IFTB gid map specific algorithm and then
-  // a more generic implementation which uses a in memory abstract version of
-  // the table.
-  //
-  // The in memory abstract map could then be deserialized/serialized back to
-  // either subtable type. For modification operations.
-  //
-  // So then we have:
-  // 1. Abstract patch selection algorithm:
-  //    a. Impl 1: using in memory patch map.
-  //    b. Impl 2: using IFTB gid/feature map directly.
-  // 2. In Memory Patch map, with support for modification. (THIS FILE)
-  // 3. Serialize/deserialize implementations from memory patch map to/from the
-  // protobuf
-  //    and IFTB mapping formats.
  public:
   struct Coverage {
     // TODO(garretrieger): move constructors?

--- a/ift/proto/patch_map.h
+++ b/ift/proto/patch_map.h
@@ -24,6 +24,8 @@ class PatchMap {
     Coverage() {}
     Coverage(std::initializer_list<uint32_t> codepoints_list)
         : codepoints(codepoints_list) {}
+    Coverage(const absl::flat_hash_set<uint32_t>& codepoints_list)
+        : codepoints(codepoints_list) {}
 
     friend void PrintTo(const Coverage& point, std::ostream* os);
 

--- a/ift/proto/patch_map.h
+++ b/ift/proto/patch_map.h
@@ -60,7 +60,10 @@ class PatchMap {
                  ift::proto::PatchEncoding default_encoding,
                  ift::proto::SubsetMapping* out) const;
 
-    bool IsDependent() const { return encoding == SHARED_BROTLI_ENCODING; }
+    bool IsDependent() const {
+      return encoding == SHARED_BROTLI_ENCODING ||
+             encoding == PER_TABLE_SHARED_BROTLI_ENCODING;
+    }
 
     Coverage coverage;
     uint32_t patch_index;

--- a/ift/proto/patch_map_test.cc
+++ b/ift/proto/patch_map_test.cc
@@ -1,0 +1,348 @@
+#include "ift/proto/patch_map.h"
+
+#include <cstdio>
+#include <cstring>
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
+#include "absl/status/status.h"
+#include "absl/types/span.h"
+#include "common/font_helper.h"
+#include "gtest/gtest.h"
+#include "ift/proto/IFT.pb.h"
+#include "patch_subset/font_data.h"
+#include "patch_subset/hb_set_unique_ptr.h"
+#include "patch_subset/sparse_bit_set.h"
+
+using absl::flat_hash_map;
+using absl::flat_hash_set;
+using absl::Span;
+using absl::Status;
+using common::FontHelper;
+using patch_subset::FontData;
+using patch_subset::hb_set_unique_ptr;
+using patch_subset::make_hb_set;
+using patch_subset::SparseBitSet;
+
+namespace ift::proto {
+
+class PatchMapTest : public ::testing::Test {
+ protected:
+  PatchMapTest() {
+    sample.set_url_template("fonts/go/here");
+    sample.set_default_patch_encoding(SHARED_BROTLI_ENCODING);
+
+    auto m = sample.add_subset_mapping();
+    hb_set_unique_ptr set = make_hb_set(2, 7, 9);
+    m->set_bias(23);
+    m->set_codepoint_set(SparseBitSet::Encode(*set.get()));
+    m->set_id_delta(0);
+
+    m = sample.add_subset_mapping();
+    set = make_hb_set(3, 10, 11, 12);
+    m->set_bias(45);
+    m->set_codepoint_set(SparseBitSet::Encode(*set.get()));
+    m->set_id_delta(0);
+    m->set_patch_encoding(IFTB_ENCODING);
+
+    overlap_sample = sample;
+
+    m = overlap_sample.add_subset_mapping();
+    set = make_hb_set(1, 55);
+    m->set_bias(0);
+    m->set_codepoint_set(SparseBitSet::Encode(*set.get()));
+    m->set_id_delta(0);
+
+    complex_ids.set_url_template("fonts/go/here");
+    complex_ids.set_default_patch_encoding(SHARED_BROTLI_ENCODING);
+
+    m = complex_ids.add_subset_mapping();
+    set = make_hb_set(1, 0);
+    m->set_bias(0);
+    m->set_codepoint_set(SparseBitSet::Encode(*set.get()));
+    m->set_id_delta(-1);
+
+    m = complex_ids.add_subset_mapping();
+    set = make_hb_set(1, 5);
+    m->set_bias(0);
+    m->set_codepoint_set(SparseBitSet::Encode(*set.get()));
+    m->set_id_delta(4);
+
+    m = complex_ids.add_subset_mapping();
+    set = make_hb_set(1, 2);
+    m->set_bias(0);
+    m->set_codepoint_set(SparseBitSet::Encode(*set.get()));
+    m->set_id_delta(-4);
+
+    m = complex_ids.add_subset_mapping();
+    set = make_hb_set(1, 4);
+    m->set_bias(0);
+    m->set_codepoint_set(SparseBitSet::Encode(*set.get()));
+    m->set_id_delta(1);
+  }
+
+  IFT empty;
+  IFT sample;
+  IFT overlap_sample;
+  IFT complex_ids;
+};
+
+TEST_F(PatchMapTest, Empty) {
+  auto map = PatchMap::FromProto(empty);
+  ASSERT_TRUE(map.ok()) << map.status();
+  PatchMap expected = {};
+  ASSERT_EQ(*map, expected);
+}
+
+TEST_F(PatchMapTest, Mapping) {
+  auto map = PatchMap::FromProto(sample);
+  ASSERT_TRUE(map.ok()) << map.status();
+
+  PatchMap expected = {
+      {{30, 32}, 1, SHARED_BROTLI_ENCODING},
+      {{55, 56, 57}, 2, IFTB_ENCODING},
+  };
+
+  ASSERT_EQ(*map, expected);
+}
+
+/* TODO XXXX
+TEST_F(PatchMapTest, Mapping_ComplexIds) {
+  auto table = IFTTable::FromProto(complex_ids);
+  ASSERT_TRUE(table.ok()) << table.status();
+
+  patch_map expected = {
+      {0, std::pair(0, SHARED_BROTLI_ENCODING)},
+      {2, std::pair(2, SHARED_BROTLI_ENCODING)},
+      {4, std::pair(4, SHARED_BROTLI_ENCODING)},
+      {5, std::pair(5, SHARED_BROTLI_ENCODING)},
+  };
+
+  ASSERT_EQ(table->GetPatchMap(), expected);
+}
+
+TEST_F(PatchMapTest, GetId_None) {
+  auto table = IFTTable::FromProto(sample);
+  ASSERT_TRUE(table.ok()) << table.status();
+
+  const uint32_t expected[4] = {0, 0, 0, 0};
+  uint32_t actual[4] = {0xFF, 0xFF, 0xFF, 0xFF};
+  table->GetId(actual);
+
+  ASSERT_EQ(expected[0], actual[0]);
+  ASSERT_EQ(expected[1], actual[1]);
+  ASSERT_EQ(expected[2], actual[2]);
+  ASSERT_EQ(expected[3], actual[3]);
+}
+
+TEST_F(PatchMapTest, GetId_Good) {
+  auto table = IFTTable::FromProto(good_id);
+  ASSERT_TRUE(table.ok()) << table.status();
+
+  const uint32_t expected[4] = {1, 2, 3, 4};
+  uint32_t actual[4] = {0xFF, 0xFF, 0xFF, 0xFF};
+  table->GetId(actual);
+
+  ASSERT_EQ(expected[0], actual[0]);
+  ASSERT_EQ(expected[1], actual[1]);
+  ASSERT_EQ(expected[2], actual[2]);
+  ASSERT_EQ(expected[3], actual[3]);
+}
+
+TEST_F(PatchMapTest, GetId_Bad) {
+  auto table = IFTTable::FromProto(bad_id);
+  ASSERT_TRUE(absl::IsInvalidArgument(table.status())) << table.status();
+}
+
+TEST_F(PatchMapTest, OverlapFails) {
+  auto table = IFTTable::FromProto(overlap_sample);
+  ASSERT_TRUE(absl::IsInvalidArgument(table.status())) << table.status();
+}
+
+TEST_F(PatchMapTest, AddPatch) {
+  auto table = IFTTable::FromProto(sample);
+  ASSERT_TRUE(table.ok()) << table.status();
+
+  Status s = table->AddPatch({77, 79, 80}, 5, SHARED_BROTLI_ENCODING);
+  ASSERT_TRUE(s.ok()) << s;
+
+  patch_map expected = {
+      {30, std::pair(1, SHARED_BROTLI_ENCODING)},
+      {32, std::pair(1, SHARED_BROTLI_ENCODING)},
+      {55, std::pair(2, IFTB_ENCODING)},
+      {56, std::pair(2, IFTB_ENCODING)},
+      {57, std::pair(2, IFTB_ENCODING)},
+      {77, std::pair(5, SHARED_BROTLI_ENCODING)},
+      {79, std::pair(5, SHARED_BROTLI_ENCODING)},
+      {80, std::pair(5, SHARED_BROTLI_ENCODING)},
+  };
+
+  ASSERT_EQ(table->GetProto().subset_mapping(2).id_delta(), 2);
+  ASSERT_GT(table->GetProto().subset_mapping(2).bias(), 0);
+  ASSERT_EQ(table->GetProto().subset_mapping(2).patch_encoding(),
+            DEFAULT_ENCODING);
+  ASSERT_EQ(table->GetPatchMap(), expected);
+}
+
+TEST_F(PatchMapTest, AddPatch_NonDefaultEncoding) {
+  auto table = IFTTable::FromProto(sample);
+  ASSERT_TRUE(table.ok()) << table.status();
+
+  Status s = table->AddPatch({77, 79, 80}, 5, IFTB_ENCODING);
+  ASSERT_TRUE(s.ok()) << s;
+
+  ASSERT_GT(table->GetProto().subset_mapping(2).bias(), 0);
+  ASSERT_EQ(table->GetProto().subset_mapping(2).patch_encoding(),
+            IFTB_ENCODING);
+  patch_map expected = {
+      {30, std::pair(1, SHARED_BROTLI_ENCODING)},
+      {32, std::pair(1, SHARED_BROTLI_ENCODING)},
+      {55, std::pair(2, IFTB_ENCODING)},
+      {56, std::pair(2, IFTB_ENCODING)},
+      {57, std::pair(2, IFTB_ENCODING)},
+      {77, std::pair(5, IFTB_ENCODING)},
+      {79, std::pair(5, IFTB_ENCODING)},
+      {80, std::pair(5, IFTB_ENCODING)},
+  };
+
+  ASSERT_EQ(table->GetPatchMap(), expected);
+}
+
+TEST_F(PatchMapTest, RemovePatches) {
+  auto table = IFTTable::FromProto(sample);
+  ASSERT_TRUE(table.ok()) << table.status();
+
+  Status s = table->RemovePatches({1});
+  ASSERT_TRUE(s.ok()) << s;
+
+  patch_map expected = {
+      {55, std::pair(2, IFTB_ENCODING)},
+      {56, std::pair(2, IFTB_ENCODING)},
+      {57, std::pair(2, IFTB_ENCODING)},
+  };
+
+  ASSERT_EQ(table->GetPatchMap(), expected);
+}
+
+TEST_F(PatchMapTest, RemovePatches_ComplexIds1) {
+  auto table = IFTTable::FromProto(complex_ids);
+  ASSERT_TRUE(table.ok()) << table.status();
+
+  Status s = table->RemovePatches({2});
+  ASSERT_TRUE(s.ok()) << s;
+
+  patch_map expected1 = {
+      {0, std::pair(0, SHARED_BROTLI_ENCODING)},
+      {4, std::pair(4, SHARED_BROTLI_ENCODING)},
+      {5, std::pair(5, SHARED_BROTLI_ENCODING)},
+  };
+
+  ASSERT_EQ(table->GetPatchMap(), expected1);
+
+  s = table->RemovePatches({4});
+  ASSERT_TRUE(s.ok()) << s;
+
+  patch_map expected2 = {
+      {0, std::pair(0, SHARED_BROTLI_ENCODING)},
+      {5, std::pair(5, SHARED_BROTLI_ENCODING)},
+  };
+
+  ASSERT_EQ(table->GetPatchMap(), expected2);
+}
+
+TEST_F(PatchMapTest, RemovePatches_ComplexIds2) {
+  auto table = IFTTable::FromProto(complex_ids);
+  ASSERT_TRUE(table.ok()) << table.status();
+
+  Status s = table->RemovePatches({5});
+  ASSERT_TRUE(s.ok()) << s;
+
+  patch_map expected = {
+      {0, std::pair(0, SHARED_BROTLI_ENCODING)},
+      {2, std::pair(2, SHARED_BROTLI_ENCODING)},
+      {4, std::pair(4, SHARED_BROTLI_ENCODING)},
+  };
+
+  ASSERT_EQ(table->GetPatchMap(), expected);
+}
+
+TEST_F(PatchMapTest, RemovePatches_ComplexIdsMultiple) {
+  auto table = IFTTable::FromProto(complex_ids);
+  ASSERT_TRUE(table.ok()) << table.status();
+
+  Status s = table->RemovePatches({0, 2});
+  ASSERT_TRUE(s.ok()) << s;
+
+  patch_map expected = {
+      {4, std::pair(4, SHARED_BROTLI_ENCODING)},
+      {5, std::pair(5, SHARED_BROTLI_ENCODING)},
+  };
+
+  ASSERT_EQ(table->GetPatchMap(), expected);
+}
+
+TEST_F(PatchMapTest, RemovePatches_None) {
+  auto table = IFTTable::FromProto(sample);
+  ASSERT_TRUE(table.ok()) << table.status();
+
+  Status s = table->RemovePatches({});
+  ASSERT_TRUE(s.ok()) << s;
+
+  patch_map expected = {
+      {30, std::pair(1, SHARED_BROTLI_ENCODING)},
+      {32, std::pair(1, SHARED_BROTLI_ENCODING)},
+      {55, std::pair(2, IFTB_ENCODING)},
+      {56, std::pair(2, IFTB_ENCODING)},
+      {57, std::pair(2, IFTB_ENCODING)},
+  };
+
+  ASSERT_EQ(table->GetPatchMap(), expected);
+}
+
+TEST_F(PatchMapTest, RemovePatches_All) {
+  auto table = IFTTable::FromProto(sample);
+  ASSERT_TRUE(table.ok()) << table.status();
+
+  Status s = table->RemovePatches({1, 2});
+  ASSERT_TRUE(s.ok()) << s;
+
+  patch_map expected = {};
+
+  ASSERT_EQ(table->GetPatchMap(), expected);
+}
+
+TEST_F(PatchMapTest, RemovePatches_BadIds) {
+  auto table = IFTTable::FromProto(sample);
+  ASSERT_TRUE(table.ok()) << table.status();
+
+  Status s = table->RemovePatches({42, 2});
+  ASSERT_TRUE(s.ok()) << s;
+
+  patch_map expected = {
+      {30, std::pair(1, SHARED_BROTLI_ENCODING)},
+      {32, std::pair(1, SHARED_BROTLI_ENCODING)},
+  };
+
+  ASSERT_EQ(table->GetPatchMap(), expected);
+}
+
+TEST_F(PatchMapTest, FromFont) {
+  auto font = IFTTable::AddToFont(roboto_ab, sample);
+  ASSERT_TRUE(font.ok()) << font.status();
+
+  hb_face_t* face = font->reference_face();
+  auto table = IFTTable::FromFont(face);
+  hb_face_destroy(face);
+
+  ASSERT_TRUE(table.ok()) << table.status();
+  ASSERT_EQ(table->GetUrlTemplate(), "fonts/go/here");
+}
+
+TEST_F(PatchMapTest, FromFont_Missing) {
+  auto table = IFTTable::FromFont(roboto_ab);
+  ASSERT_FALSE(table.ok()) << table.status();
+  ASSERT_TRUE(absl::IsNotFound(table.status()));
+}
+*/
+
+}  // namespace ift::proto

--- a/ift/proto/patch_map_test.cc
+++ b/ift/proto/patch_map_test.cc
@@ -324,4 +324,11 @@ TEST_F(PatchMapTest, AddToProto_ComplexIds) {
       << Diff(expected, proto);
 }
 
+TEST_F(PatchMapTest, IsDependent) {
+  ASSERT_FALSE(PatchMap::Entry({}, 0, IFTB_ENCODING).IsDependent());
+  ASSERT_TRUE(PatchMap::Entry({}, 0, SHARED_BROTLI_ENCODING).IsDependent());
+  ASSERT_TRUE(
+      PatchMap::Entry({}, 0, PER_TABLE_SHARED_BROTLI_ENCODING).IsDependent());
+}
+
 }  // namespace ift::proto

--- a/ift/proto/patch_map_test.cc
+++ b/ift/proto/patch_map_test.cc
@@ -301,6 +301,50 @@ TEST_F(PatchMapTest, AddToProto) {
       << Diff(expected, proto);
 }
 
+TEST_F(PatchMapTest, AddToProto_ExtensionFilter) {
+  PatchMap map = {
+      {{23, 25, 28}, 0, SHARED_BROTLI_ENCODING},
+      {{25, 28, 37}, 1, SHARED_BROTLI_ENCODING},
+      {{30, 31}, 2, SHARED_BROTLI_ENCODING, true},
+  };
+
+  IFT expected_1;
+  IFT expected_2;
+  expected_1.set_default_patch_encoding(SHARED_BROTLI_ENCODING);
+  expected_2.set_default_patch_encoding(SHARED_BROTLI_ENCODING);
+
+  auto* m = expected_1.add_subset_mapping();
+  hb_set_unique_ptr set = make_hb_set(3, 0, 2, 5);
+  m->set_bias(23);
+  m->set_codepoint_set(SparseBitSet::Encode(*set.get()));
+  m->set_id_delta(-1);
+
+  m = expected_1.add_subset_mapping();
+  set = make_hb_set(3, 0, 3, 12);
+  m->set_bias(25);
+  m->set_codepoint_set(SparseBitSet::Encode(*set.get()));
+  m->set_id_delta(0);
+
+  m = expected_2.add_subset_mapping();
+  set = make_hb_set(2, 0, 1);
+  m->set_bias(30);
+  m->set_codepoint_set(SparseBitSet::Encode(*set.get()));
+  m->set_id_delta(1);
+
+  IFT proto_1;
+  proto_1.set_default_patch_encoding(SHARED_BROTLI_ENCODING);
+  map.AddToProto(proto_1);
+
+  IFT proto_2;
+  proto_2.set_default_patch_encoding(SHARED_BROTLI_ENCODING);
+  map.AddToProto(proto_2, true);
+
+  ASSERT_TRUE(MessageDifferencer::Equals(expected_1, proto_1))
+      << Diff(expected_1, proto_1);
+  ASSERT_TRUE(MessageDifferencer::Equals(expected_2, proto_2))
+      << Diff(expected_2, proto_2);
+}
+
 TEST_F(PatchMapTest, AddToProto_ComplexIds) {
   PatchMap map = {
       {{23, 25, 28}, 0, SHARED_BROTLI_ENCODING},

--- a/ift/proto/patch_map_test.cc
+++ b/ift/proto/patch_map_test.cc
@@ -100,6 +100,24 @@ std::string Diff(const IFT& a, const IFT& b) {
   return StrCat("Expected:\n", a_str, "\n", "Actual:\n", b_str);
 }
 
+TEST_F(PatchMapTest, AddFromProto) {
+  PatchMap map;
+  auto s = map.AddFromProto(sample);
+  s.Update(map.AddFromProto(complex_ids, true));
+  ASSERT_TRUE(s.ok()) << s;
+
+  PatchMap expected = {
+      {{30, 32}, 1, SHARED_BROTLI_ENCODING},
+      {{55, 56, 57}, 2, IFTB_ENCODING},
+      {{0}, 0, SHARED_BROTLI_ENCODING, true},
+      {{5}, 5, SHARED_BROTLI_ENCODING, true},
+      {{2}, 2, SHARED_BROTLI_ENCODING, true},
+      {{4}, 4, SHARED_BROTLI_ENCODING, true},
+  };
+
+  ASSERT_EQ(map, expected);
+}
+
 TEST_F(PatchMapTest, Empty) {
   auto map = PatchMap::FromProto(empty);
   ASSERT_TRUE(map.ok()) << map.status();

--- a/js_client/BUILD
+++ b/js_client/BUILD
@@ -32,6 +32,7 @@ cc_binary(
     name = "ift_client",
     srcs = [
         "ift_client.cc",
+        "ift_client.h",
     ],
     linkopts = DEFAULT_EMSCRIPTEN_LINKOPTS,
     copts = [

--- a/js_client/ift_client.cc
+++ b/js_client/ift_client.cc
@@ -162,7 +162,8 @@ void State::Process() {
   if (inflight_urls_.empty()) {
     auto state = client_->Process();
     if (!state.ok()) {
-      LOG(WARNING) << "Failed to process in the client: " << sc.message();
+      LOG(WARNING) << "Failed to process in the client: "
+                   << state.status().message();
       SendCallbacks(false);
       return;
     }

--- a/js_client/ift_client.cc
+++ b/js_client/ift_client.cc
@@ -1,4 +1,4 @@
-#include "ift/ift_client.h"
+#include "js_client/ift_client.h"
 
 #include <emscripten/bind.h>
 #include <emscripten/fetch.h>
@@ -17,6 +17,7 @@
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
 #include "ift/encoder/encoder.h"
+#include "ift/ift_client.h"
 #include "ift/proto/IFT.pb.h"
 #include "patch_subset/font_data.h"
 #include "patch_subset/hb_set_unique_ptr.h"
@@ -34,97 +35,18 @@ using patch_subset::FontData;
 using patch_subset::hb_set_unique_ptr;
 using patch_subset::make_hb_set;
 
-typedef flat_hash_map<std::string, uint32_t> patch_set;
-
-class State;
-
-struct RequestContext {
-  RequestContext(const patch_set& urls_, val& callback_)
-      : urls(urls_), callback(std::move(callback_)) {}
-
-  bool IsComplete() { return urls.empty(); }
-
-  void UrlSuceeded(const std::string& url, FontData data) {
-    auto it = urls.find(url);
-    if (it != urls.end()) {
-      uint32_t id = it->second;
-      client->AddPatch(id, data);
-    } else {
-      LOG(WARNING) << "No id found for url.";
-      failed_ = true;
-    }
-
-    RemoveUrl(url);
-  }
-
-  void UrlFailed(const std::string& url) {
-    failed_ = true;
-    RemoveUrl(url);
-  }
-
-  patch_set urls;
-  val callback;
-  IFTClient* client;
-
- private:
-  void RemoveUrl(const std::string& url) {
-    urls.erase(url);
-    FinalizeIfNeeded();
-  }
-
-  void FinalizeIfNeeded() {
-    if (!IsComplete()) {
-      return;
-    }
-
-    if (failed_) {
-      callback(false);
-      return;
-    }
-
-    auto state = client->Process();
-    if (!state.ok()) {
-      LOG(WARNING) << "IFTClient::Process failed: " << state.status().message();
-      callback(false);
-      return;
-    }
-
-    if (*state == IFTClient::READY) {
-      callback(true);
-      return;
-    }
-
-    if (*state == IFTClient::NEEDS_PATCHES) {
-      // TODO(garretrieger): retrigger state.extend to cause any outstanding
-      // patches to be fetched.
-      LOG(WARNING)
-          << "Need additional patches, but this is currently unsupported.";
-      callback(false);
-      return;
-    }
-
-    LOG(WARNING) << "Unknown client state: " << *state;
-    callback(false);
-  }
-
-  bool failed_ = false;
-};
-
 void RequestSucceeded(emscripten_fetch_t* fetch) {
   std::string url(fetch->url);
-  RequestContext* context = reinterpret_cast<RequestContext*>(fetch->userData);
+  State* state = reinterpret_cast<State*>(fetch->userData);
   if (fetch->status == 200) {
     FontData response(absl::string_view(fetch->data, fetch->numBytes));
-    context->UrlSuceeded(url, std::move(response));
+    state->UrlLoaded(url, std::move(response));
   } else {
     LOG(WARNING) << "Patch load of " << url << " failed with code "
                  << fetch->status;
-    context->UrlFailed(url);
+    state->Failure();
   }
 
-  if (context->IsComplete()) {
-    delete context;
-  }
   emscripten_fetch_close(fetch);
 }
 
@@ -132,147 +54,26 @@ void RequestFailed(emscripten_fetch_t* fetch) {
   std::string url(fetch->url);
   LOG(WARNING) << "Patch load of " << url << " failed.";
 
-  RequestContext* context = reinterpret_cast<RequestContext*>(fetch->userData);
-  context->UrlFailed(url);
-  if (context->IsComplete()) {
-    delete context;
-  }
+  State* state = reinterpret_cast<State*>(fetch->userData);
+  state->Failure();
   emscripten_fetch_close(fetch);
 }
 
-struct InitRequestContext {
-  InitRequestContext(val& callback_, flat_hash_set<uint32_t>& codepoints_)
-      : callback(std::move(callback_)), codepoints(std::move(codepoints_)) {}
-  State* state;
-  val callback;
-  flat_hash_set<uint32_t> codepoints;
-};
-
-static void InitRequestSucceeded(emscripten_fetch_t* fetch);
-static void InitRequestFailed(emscripten_fetch_t* fetch);
-
-class State {
- public:
-  State(std::string font_url) : font_url_(font_url), client_() {}
-
-  val font_data() {
-    if (client_) {
-      return val(typed_memory_view(client_->GetFontData().size(),
-                                   client_->GetFontData().data()));
-    }
-    return val(typed_memory_view(0, (uint32_t*)nullptr));
-  }
-
-  void extend(val codepoints_js, val callback) {
-    std::vector<int> codepoints_vector =
-        convertJSArrayToNumberVector<int>(codepoints_js);
-
-    flat_hash_set<uint32_t> codepoints;
-    std::copy(codepoints_vector.begin(), codepoints_vector.end(),
-              std::inserter(codepoints, codepoints.begin()));
-
-    extend_(std::move(codepoints), std::move(callback));
-  }
-
-  void init_client(IFTClient&& client) { client_ = std::move(client); }
-
-  void extend_(flat_hash_set<uint32_t> codepoints, val callback) {
-    // TODO(garretrieger): queue up and save any codepoints seen so far if the
-    // init request
-    //                     is in flight.
-    // TODO(garretrieger): track in flight URLs so we don't re-issue the
-    // requests for them.
-    if (!client_) {
-      // This will load the init font file and then re-run extend once we have
-      // it.
-      DoInitRequest(std::move(codepoints), callback);
-      return;
-    }
-
-    auto sc = client_->AddDesiredCodepoints(codepoints);
-    if (!sc.ok()) {
-      LOG(WARNING) << "Failed to add desired codepoints to the client: "
-                   << sc.message();
-      callback(false);
-      return;
-    }
-
-    patch_set urls;
-    for (uint32_t id : client_->PatchesNeeded()) {
-      std::string url = client_->PatchToUrl(id);
-      urls[url] = id;
-    }
-
-    if (urls.empty()) {
-      callback(true);
-      return;
-    }
-
-    DoRequest(urls, callback);
-  }
-
- private:
-  void DoInitRequest(flat_hash_set<uint32_t> codepoints, val& callback) {
-    InitRequestContext* context = new InitRequestContext(callback, codepoints);
-    context->state = this;
-
-    emscripten_fetch_attr_t attr;
-    emscripten_fetch_attr_init(&attr);
-    strcpy(attr.requestMethod, "GET");
-    attr.attributes = EMSCRIPTEN_FETCH_LOAD_TO_MEMORY;
-
-    attr.userData = context;
-    attr.onsuccess = InitRequestSucceeded;
-    attr.onerror = InitRequestFailed;
-
-    emscripten_fetch(&attr, font_url_.c_str());
-  }
-
-  void DoRequest(const patch_set& urls, val& callback) {
-    if (!client_) {
-      callback(false);
-      return;
-    }
-
-    RequestContext* context = new RequestContext(urls, callback);
-    context->client = &(*client_);
-
-    for (auto p : urls) {
-      const std::string& url = p.first;
-
-      emscripten_fetch_attr_t attr;
-      emscripten_fetch_attr_init(&attr);
-      strcpy(attr.requestMethod, "GET");
-      attr.attributes = EMSCRIPTEN_FETCH_LOAD_TO_MEMORY;
-
-      attr.userData = context;
-      attr.onsuccess = RequestSucceeded;
-      attr.onerror = RequestFailed;
-
-      emscripten_fetch(&attr, url.c_str());
-    }
-  }
-
-  std::string font_url_;
-  std::optional<IFTClient> client_;
-};
-
 void InitRequestSucceeded(emscripten_fetch_t* fetch) {
-  InitRequestContext* context =
-      reinterpret_cast<InitRequestContext*>(fetch->userData);
+  State* state = reinterpret_cast<State*>(fetch->userData);
   FontData response;
   string_view response_data;
 
   if (fetch->status != 200) {
     LOG(WARNING) << "Extend http request failed with code " << fetch->status;
-    context->callback(false);
+    state->Failure();
     goto cleanup;
   }
 
   response_data = string_view(fetch->data, fetch->numBytes);
   if (response_data.size() < 4) {
     LOG(WARNING) << "Response is too small.";
-    context->callback(false);
+    state->Failure();
     goto cleanup;
   }
 
@@ -280,7 +81,7 @@ void InitRequestSucceeded(emscripten_fetch_t* fetch) {
     auto r = Encoder::DecodeWoff2(response_data);
     if (!r.ok()) {
       LOG(WARNING) << "WOFF2 decoding failed: " << r.status();
-      context->callback(false);
+      state->Failure();
       goto cleanup;
     }
     response = std::move(*r);
@@ -292,28 +93,150 @@ void InitRequestSucceeded(emscripten_fetch_t* fetch) {
     auto client = IFTClient::NewClient(std::move(response));
     if (!client.ok()) {
       LOG(WARNING) << "Creating client failed: " << client.status();
-      context->callback(false);
+      state->Failure();
       goto cleanup;
     }
-    context->state->init_client(std::move(*client));
+    state->InitClient(std::move(*client));
   }
 
-  // Now that we have the base file we need to trigger loading of any needed
-  // patches re-call extend.
-  context->state->extend_(std::move(context->codepoints),
-                          std::move(context->callback));
-
 cleanup:
-  delete context;
   emscripten_fetch_close(fetch);
 }
 
 void InitRequestFailed(emscripten_fetch_t* fetch) {
-  InitRequestContext* context =
-      reinterpret_cast<InitRequestContext*>(fetch->userData);
-  context->callback(false);
-  delete context;
+  State* state = reinterpret_cast<State*>(fetch->userData);
+  state->Failure();
   emscripten_fetch_close(fetch);
+}
+
+void State::extend(val codepoints_js, val callback) {
+  std::vector<int> codepoints_vector =
+      convertJSArrayToNumberVector<int>(codepoints_js);
+
+  std::copy(codepoints_vector.begin(), codepoints_vector.end(),
+            std::inserter(pending_codepoints_, pending_codepoints_.begin()));
+  callbacks_.push_back(std::move(callback));
+
+  Process();
+}
+
+void State::Process() {
+  // TODO(garretrieger): queue up and save any codepoints seen so far if the
+  // init request
+  //                     is in flight.
+  // TODO(garretrieger): track in flight URLs so we don't re-issue the
+  // requests for them.
+  if (!client_) {
+    // This will load the init font file and then re-run extend once we have
+    // it.
+    if (!init_request_in_flight_) {
+      init_request_in_flight_ = true;
+      SendInitRequest();
+    }
+    return;
+  }
+
+  auto sc = client_->AddDesiredCodepoints(pending_codepoints_);
+  if (!sc.ok()) {
+    LOG(WARNING) << "Failed to add desired codepoints to the client: "
+                 << sc.message();
+    SendCallbacks(false);
+    return;
+  }
+
+  patch_set urls_to_load;
+  for (uint32_t id : client_->PatchesNeeded()) {
+    std::string url = client_->PatchToUrl(id);
+    if (inflight_urls_.contains(url)) {
+      continue;
+    }
+    inflight_urls_[url] = id;
+    urls_to_load[url] = id;
+  }
+
+  if (!urls_to_load.empty()) {
+    LoadUrls(urls_to_load);
+    return;
+  }
+
+  if (inflight_urls_.empty()) {
+    auto state = client_->Process();
+    if (!state.ok()) {
+      LOG(WARNING) << "Failed to process in the client: " << sc.message();
+      SendCallbacks(false);
+      return;
+    }
+
+    if (*state == IFTClient::NEEDS_PATCHES) {
+      Process();
+      return;
+    }
+
+    if (*state == IFTClient::READY) {
+      SendCallbacks(true);
+      return;
+    }
+
+    LOG(WARNING) << "Unrecognized ift client state: " << *state;
+    SendCallbacks(false);
+  }
+}
+
+void State::UrlLoaded(std::string url, const FontData& data) {
+  auto it = inflight_urls_.find(url);
+  if (it != inflight_urls_.end()) {
+    uint32_t id = it->second;
+    client_->AddPatch(id, data);
+    inflight_urls_.erase(it);
+    if (inflight_urls_.empty()) {
+      Process();
+    }
+  } else {
+    LOG(WARNING) << "No id found for url.";
+    SendCallbacks(false);
+  }
+}
+
+void State::SendCallbacks(bool status) {
+  for (auto& callback : callbacks_) {
+    callback(status);
+  }
+  callbacks_.clear();
+}
+
+void State::SendInitRequest() {
+  emscripten_fetch_attr_t attr;
+  emscripten_fetch_attr_init(&attr);
+  strcpy(attr.requestMethod, "GET");
+  attr.attributes = EMSCRIPTEN_FETCH_LOAD_TO_MEMORY;
+
+  attr.userData = this;
+  attr.onsuccess = InitRequestSucceeded;
+  attr.onerror = InitRequestFailed;
+
+  emscripten_fetch(&attr, font_url_.c_str());
+}
+
+void State::LoadUrls(const patch_set& urls) {
+  if (!client_) {
+    Failure();
+    return;
+  }
+
+  for (auto p : urls) {
+    const std::string& url = p.first;
+
+    emscripten_fetch_attr_t attr;
+    emscripten_fetch_attr_init(&attr);
+    strcpy(attr.requestMethod, "GET");
+    attr.attributes = EMSCRIPTEN_FETCH_LOAD_TO_MEMORY;
+
+    attr.userData = this;
+    attr.onsuccess = RequestSucceeded;
+    attr.onerror = RequestFailed;
+
+    emscripten_fetch(&attr, url.c_str());
+  }
 }
 
 EMSCRIPTEN_BINDINGS(ift) {

--- a/js_client/ift_client.h
+++ b/js_client/ift_client.h
@@ -1,0 +1,50 @@
+#ifndef JS_CLIENT_IFT_CLIENT_H_
+#define JS_CLIENT_IFT_CLIENT_H_
+
+#include <emscripten/val.h>
+
+#include <string>
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
+#include "ift/ift_client.h"
+
+typedef absl::flat_hash_map<std::string, uint32_t> patch_set;
+
+class State {
+ public:
+  State(std::string font_url) : font_url_(font_url), client_() {}
+
+  emscripten::val font_data() {
+    if (client_) {
+      return emscripten::val(emscripten::typed_memory_view(
+          client_->GetFontData().size(), client_->GetFontData().data()));
+    }
+    return emscripten::val(
+        emscripten::typed_memory_view(0, (uint32_t*)nullptr));
+  }
+
+  void extend(emscripten::val codepoints_js, emscripten::val callback);
+
+  void InitClient(ift::IFTClient&& client) {
+    client_ = std::move(client);
+    Process();
+  }
+  void Process();
+  void Failure() { SendCallbacks(false); }
+  void UrlLoaded(std::string url, const patch_subset::FontData& data);
+
+ private:
+  void SendInitRequest();
+  void LoadUrls(const patch_set& urls);
+  void SendCallbacks(bool status);
+
+  std::string font_url_;
+  std::optional<ift::IFTClient> client_;
+  absl::flat_hash_set<uint32_t> pending_codepoints_;
+  bool init_request_in_flight_ = false;
+  patch_set inflight_urls_;
+  std::vector<emscripten::val> callbacks_;
+};
+
+#endif  // JS_CLIENT

--- a/util/font2ift.cc
+++ b/util/font2ift.cc
@@ -3,6 +3,7 @@
 #include <sstream>
 #include <vector>
 
+#include "absl/container/btree_set.h"
 #include "absl/container/flat_hash_set.h"
 #include "absl/flags/flag.h"
 #include "absl/flags/parse.h"
@@ -26,6 +27,12 @@ ABSL_FLAG(std::string, output_font, "out.ttf",
 ABSL_FLAG(std::string, url_template, "patch$5$4$3$2$1.br",
           "Url template for patch files.");
 
+ABSL_FLAG(std::string, input_iftb_patch_template, "",
+          "Template used to locate existing iftb patches which should be "
+          "used in the output IFT font. If set the input codepoints files "
+          "are interpretted as patch indices instead of codepoints.");
+
+using absl::btree_set;
 using absl::flat_hash_set;
 using absl::Status;
 using absl::StatusOr;
@@ -33,6 +40,19 @@ using absl::StrCat;
 using ift::IFTClient;
 using ift::encoder::Encoder;
 using patch_subset::FontData;
+
+FontData load_iftb_patch(uint32_t index) {
+  std::string path = IFTClient::PatchToUrl(
+      absl::GetFlag(FLAGS_input_iftb_patch_template), index);
+  hb_blob_t* blob = hb_blob_create_from_file_or_fail(path.c_str());
+  if (!blob) {
+    fprintf(stderr, "failed to load file: %s\n", path.c_str());
+    exit(-1);
+  }
+
+  FontData result(blob);
+  return result;
+}
 
 hb_face_t* load_font(const char* filename) {
   hb_blob_t* blob = hb_blob_create_from_file_or_fail(filename);
@@ -89,6 +109,19 @@ Status write_file(const std::string& name, const FontData& data) {
   return absl::OkStatus();
 }
 
+void write_patch(const Encoder& encoder, uint32_t id, const FontData& patch) {
+  std::string output_path = absl::GetFlag(FLAGS_output_path);
+
+  std::string name = IFTClient::PatchToUrl(encoder.UrlTemplate(), id);
+  std::cerr << "  Writing patch: " << StrCat(output_path, "/", name)
+            << std::endl;
+  auto sc = write_file(StrCat(output_path, "/", name), patch);
+  if (!sc.ok()) {
+    std::cerr << sc.message() << std::endl;
+    exit(-1);
+  }
+}
+
 int write_output(const Encoder& encoder, const FontData& base_font) {
   std::string output_path = absl::GetFlag(FLAGS_output_path);
   std::string output_font = absl::GetFlag(FLAGS_output_font);
@@ -102,15 +135,7 @@ int write_output(const Encoder& encoder, const FontData& base_font) {
   }
 
   for (const auto& p : encoder.Patches()) {
-    std::string name = IFTClient::PatchToUrl(encoder.UrlTemplate(), p.first);
-
-    std::cerr << "Writing patch: " << StrCat(output_path, "/", name)
-              << std::endl;
-    auto sc = write_file(StrCat(output_path, "/", name), p.second);
-    if (!sc.ok()) {
-      std::cerr << sc.message() << std::endl;
-      return -1;
-    }
+    write_patch(encoder, p.first, p.second);
   }
 
   return 0;
@@ -139,7 +164,10 @@ int main(int argc, char** argv) {
     return -1;
   }
 
+  bool mixed_mode = !absl::GetFlag(FLAGS_input_iftb_patch_template).empty();
+
   Encoder encoder;
+  encoder.SetUrlTemplate(absl::GetFlag(FLAGS_url_template));
   {
     hb_face_t* input_font = load_font(args[1]);
     encoder.SetFace(input_font);
@@ -147,6 +175,39 @@ int main(int argc, char** argv) {
   }
 
   bool first = true;
+  if (mixed_mode) {
+    // Load and write out iftb patches
+    std::cout << ">> loading input iftb patches:" << std::endl;
+    for (size_t i = 2; i < args.size(); i++) {
+      auto s = load_unicodes_file(args[i]);
+      btree_set<uint32_t> ordered;
+      std::copy(s->begin(), s->end(), std::inserter(ordered, ordered.begin()));
+      if (!s.ok()) {
+        std::cerr << "Failed to load codepoint file (" << args[i]
+                  << "): " << s.status().message() << std::endl;
+        return -1;
+      }
+
+      for (uint32_t id : ordered) {
+        FontData iftb_patch = load_iftb_patch(id);
+        auto sc = encoder.AddExistingIftbPatch(id, iftb_patch);
+        if (!sc.ok()) {
+          std::cout << "Failed adding existing iftb patch: " << sc.message()
+                    << std::endl;
+          return -1;
+        }
+
+        if (!first) {
+          write_patch(encoder, id, iftb_patch);
+        }
+      }
+
+      first = false;
+    }
+  }
+
+  std::cout << ">> configuring encoder:" << std::endl;
+  first = true;
   for (size_t i = 2; i < args.size(); i++) {
     auto s = load_unicodes_file(args[i]);
     if (!s.ok()) {
@@ -154,19 +215,27 @@ int main(int argc, char** argv) {
       return -1;
     }
 
+    Status sc;
     if (first) {
-      auto sc = encoder.SetBaseSubset(*s);
+      sc = !mixed_mode ? encoder.SetBaseSubset(*s)
+                       : encoder.SetBaseSubsetFromIftbPatches(*s);
       if (!sc.ok()) {
         std::cerr << sc.message() << std::endl;
         return -1;
       }
       first = false;
-    } else {
+    } else if (!mixed_mode) {
       encoder.AddExtensionSubset(*s);
+    } else {
+      sc = encoder.AddExtensionSubsetOfIftbPatches(*s);
+      if (!sc.ok()) {
+        std::cerr << sc.message() << std::endl;
+        return -1;
+      }
     }
   }
 
-  encoder.SetUrlTemplate(absl::GetFlag(FLAGS_url_template));
+  std::cout << ">> encoding:" << std::endl;
   auto base_font = encoder.Encode();
   base_font = Encoder::EncodeWoff2(base_font->str(), false);
   if (!base_font.ok()) {
@@ -174,5 +243,6 @@ int main(int argc, char** argv) {
     return -1;
   }
 
+  std::cout << ">> generating output patches:" << std::endl;
   return write_output(encoder, *base_font);
 }

--- a/util/iftb2ift.cc
+++ b/util/iftb2ift.cc
@@ -97,7 +97,7 @@ int main(int argc, char** argv) {
   } else if (out_format == "proto") {
     std::cout << ift->SerializeAsString();
   } else if (out_format == "font" || out_format == "woff2") {
-    auto out_font = IFTTable::AddToFont(face, *ift, true);
+    auto out_font = IFTTable::AddToFont(face, *ift, nullptr, true);
     if (!out_font.ok()) {
       std::cerr << out_font.status();
       return -1;


### PR DESCRIPTION
Extends the prototype IFT mapping format to support encoding fonts with a mix of patches types:
- Add a second extension IFT mapping table to allow shared brotli and IFTB to avoid updating the same table.
- Updated client interface and patch selection logic.
- Updated encoder to be able to produced mixed IFT mappings.
- Added third patch format: per table shared brotli patches.