### PR TITLE
Update encoder to ensure loca length stays the same in mixed mode.

### DIFF
--- a/common/BUILD
+++ b/common/BUILD
@@ -77,6 +77,7 @@ cc_test(
     ],
     data = [
         "//patch_subset:testdata",
+        "//ift:testdata",
     ],
     deps = [
         ":common",

--- a/common/font_helper_test.cc
+++ b/common/font_helper_test.cc
@@ -103,8 +103,6 @@ TEST_F(FontHelperTest, GlyfData_Long) {
   data = FontHelper::GlyfData(noto_sans_ift_ttf.get(), 1055);
   ASSERT_TRUE(data.ok()) << data.status();
   ASSERT_EQ(data->size(), 0);
-
-  // TODO
 }
 
 TEST_F(FontHelperTest, Loca) {

--- a/ift/BUILD
+++ b/ift/BUILD
@@ -66,5 +66,6 @@ filegroup(
     srcs = glob(["testdata/**"]),
     visibility = [
         "//ift:__subpackages__",
+        "//common:__subpackages__",
     ],
 )

--- a/ift/iftb_binary_patch.cc
+++ b/ift/iftb_binary_patch.cc
@@ -143,9 +143,8 @@ Status IftbBinaryPatch::Patch(const FontData& font_base,
     return absl::InvalidArgumentError("Failed to unpack the chunks.");
   }
 
-  std::string font_data = font_base.string();
   sfnt sfnt;
-  sfnt.setBuffer(font_data);
+  sfnt.setBuffer((char*)font_base.data(), font_base.size());
   if (!sfnt.read()) {
     return absl::InvalidArgumentError("Failed to read input font file.");
   }
@@ -167,7 +166,7 @@ Status IftbBinaryPatch::Patch(const FontData& font_base,
   std::string new_font_data;
   new_font_data.resize(new_length, 0);
 
-  if (!merger.merge(sfnt, font_data.data(), new_font_data.data())) {
+  if (!merger.merge(sfnt, (char*)font_base.data(), new_font_data.data())) {
     return absl::InvalidArgumentError("IFTB Patch merging failed.");
   }
 


### PR DESCRIPTION
The current IFTB patch merging implementation doesn't support changing loca len, so for now update the encoder to keep it constant. Also expands tests to cover this case and check glyph presence in addition to codepoint presence.