### PR TITLE
Reenable integration tests using the fontations rust client.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -161,10 +161,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "fontations",
-    urls = ["https://github.com/googlefonts/fontations/archive/eba2ce7e6b2fdbc0ee74e2a24773caacb5a95499.zip"],
-    strip_prefix = "fontations-eba2ce7e6b2fdbc0ee74e2a24773caacb5a95499",
+    urls = ["https://github.com/googlefonts/fontations/archive/699d1251d8a1959d2a45758719ee24d1e9655b3f.zip"],
+    strip_prefix = "fontations-699d1251d8a1959d2a45758719ee24d1e9655b3f",
     build_file = "//third_party:fontations.BUILD",
-    integrity = "sha256-8UcPJGfqmCoz0Xg7AiTHqp85gELW3ovmu4zyElMUGGQ=",
+    integrity = "sha256-+YH7Wbn43uYhJhdUoDkIuVVSzmGukXE+mOikx7aUjyw=",
 )
 
 http_archive(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -161,10 +161,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "fontations",
-    urls = ["https://github.com/googlefonts/fontations/archive/699d1251d8a1959d2a45758719ee24d1e9655b3f.zip"],
-    strip_prefix = "fontations-699d1251d8a1959d2a45758719ee24d1e9655b3f",
+    urls = ["https://github.com/googlefonts/fontations/archive/b3514837812c462d94707bd0afc41b11e8cc4e6d.zip"],
+    strip_prefix = "fontations-b3514837812c462d94707bd0afc41b11e8cc4e6d",
     build_file = "//third_party:fontations.BUILD",
-    integrity = "sha256-+YH7Wbn43uYhJhdUoDkIuVVSzmGukXE+mOikx7aUjyw=",
+    integrity = "sha256-HDDXjyJGNYemgLVp7XNFaFawWTyv8lgPEWfrgfzdFE8=",
 )
 
 http_archive(

--- a/fontations/Cargo.lock
+++ b/fontations/Cargo.lock
@@ -781,6 +781,7 @@ dependencies = [
  "data-encoding-macro",
  "font-test-data",
  "font-types",
+ "klippa",
  "read-fonts",
  "regex",
  "shared-brotli-patch-decoder",
@@ -1393,7 +1394,7 @@ checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
 
 [[package]]
 name = "skrifa"
-version = "0.26.3"
+version = "0.26.4"
 dependencies = [
  "bytemuck",
  "core_maths",

--- a/ift/client/fontations_client.h
+++ b/ift/client/fontations_client.h
@@ -27,12 +27,16 @@ absl::Status ToGraph(const ift::encoder::Encoder& encoder,
 /**
  * Runs 'ift_extend' on the IFT font created by encoder and returns the
  * resulting extended font.
+ *
+ * if non null, applied_uris will be populated with the set of uris that
+ * the client ended up fetching and applying.
  */
 absl::StatusOr<common::FontData> ExtendWithDesignSpace(
     const ift::encoder::Encoder& encoder, const common::FontData& ift_font,
     absl::btree_set<uint32_t> codepoints,
     absl::btree_set<hb_tag_t> feature_tags,
-    absl::flat_hash_map<hb_tag_t, common::AxisRange> design_space);
+    absl::flat_hash_map<hb_tag_t, common::AxisRange> design_space,
+    absl::btree_set<std::string>* applied_uris = nullptr);
 
 absl::StatusOr<common::FontData> Extend(const ift::encoder::Encoder& encoder,
                                         const common::FontData& ift_font,

--- a/ift/client/fontations_client.h
+++ b/ift/client/fontations_client.h
@@ -31,6 +31,7 @@ absl::Status ToGraph(const ift::encoder::Encoder& encoder,
 absl::StatusOr<common::FontData> ExtendWithDesignSpace(
     const ift::encoder::Encoder& encoder, const common::FontData& ift_font,
     absl::btree_set<uint32_t> codepoints,
+    absl::btree_set<hb_tag_t> feature_tags,
     absl::flat_hash_map<hb_tag_t, common::AxisRange> design_space);
 
 absl::StatusOr<common::FontData> Extend(const ift::encoder::Encoder& encoder,

--- a/ift/integration_test.cc
+++ b/ift/integration_test.cc
@@ -251,8 +251,6 @@ bool GvarDataMatches(hb_face_t* a, hb_face_t* b, uint32_t codepoint,
 
 // TODO(garretrieger): full expansion test.
 // TODO(garretrieger): test of a woff2 encoded IFT font.
-// TODO(garretrieger): add IFTB only test case.
-// TODO(garretrieger): extension specific url template.
 
 TEST_F(IntegrationTest, TableKeyedOnly) {
   Encoder encoder;
@@ -791,10 +789,9 @@ TEST_F(IntegrationTest, MixedMode_DesignSpaceAugmentation) {
       GvarDataMatches(orig_face.get(), extended_face.get(), chunk3_cp, 7));
 }
 
-/*
 TEST_F(IntegrationTest, MixedMode_DesignSpaceAugmentation_DropsUnusedPatches) {
   Encoder encoder;
-  auto sc = InitEncoderForVfIftb(encoder);
+  auto sc = InitEncoderForVfMixedMode(encoder);
   ASSERT_TRUE(sc.ok()) << sc;
 
   // target paritions: {{0, 1}, {2}, {3, 4}} + add wght axis
@@ -804,65 +801,34 @@ TEST_F(IntegrationTest, MixedMode_DesignSpaceAugmentation_DropsUnusedPatches) {
   sc.Update(encoder.AddExtensionSubsetOfIftbPatches({3, 4}));
   encoder.AddOptionalDesignSpace({{kWght, *AxisRange::Range(100, 900)}});
   encoder.AddIftbUrlTemplateOverride({{kWght, *AxisRange::Range(100, 900)}},
-                                     "vf-0x$2$1");
+                                     "vf-{id}");
 
   ASSERT_TRUE(sc.ok()) << sc;
 
   auto encoded = encoder.Encode();
   ASSERT_TRUE(encoded.ok()) << encoded.status();
+  auto encoded_face = encoded->face();
 
-  auto client = IFTClient::NewClient(std::move(*encoded));
-  ASSERT_TRUE(client.ok()) << client.status();
+  btree_set<std::string> fetched_uris;
+  auto extended = ExtendWithDesignSpace(
+      encoder, *encoded, {chunk3_cp, chunk4_cp}, {},
+      {{kWght, *AxisRange::Range(100, 900)}}, &fetched_uris);
 
-  // Phase 1
-  client->AddDesiredCodepoints({chunk3_cp, chunk4_cp});
-  sc = client->AddDesiredDesignSpace(kWght, 100, 900);
-  ASSERT_TRUE(sc.ok()) << sc;
-  auto state = client->Process();
-  ASSERT_TRUE(state.ok()) << state.status();
-  ASSERT_EQ(*state, IFTClient::NEEDS_PATCHES);
+  // correspond to ids 3, 4, 6, d
+  btree_set<std::string> expected_uris{"0C", "0G",    "0O",
+                                       "1K", "vf-0C", "vf-0G"};
 
-  auto patches = client->PatchesNeeded();
-  flat_hash_set<std::string> expected_patches = {"0x03", "0x04", "0x06"};
-  ASSERT_EQ(patches, expected_patches);
-  sc = AddPatches(*client, encoder);
-  ASSERT_TRUE(sc.ok()) << sc;
+  ASSERT_EQ(fetched_uris, expected_uris);
 
-  state = client->Process();
-  ASSERT_TRUE(state.ok()) << state.status();
-  ASSERT_EQ(*state, IFTClient::NEEDS_PATCHES);
+  // TODO check the patches that were used by looking at ift_extend output
+  ASSERT_TRUE(extended.ok()) << extended.status();
+  auto extended_face = extended->face();
 
-  // Phase 2
-  patches = client->PatchesNeeded();
-  expected_patches = {"0x0d"};
-  ASSERT_EQ(patches, expected_patches);
-  sc = AddPatches(*client, encoder);
-  ASSERT_TRUE(sc.ok()) << sc;
-
-  state = client->Process();
-  ASSERT_TRUE(state.ok()) << state.status();
-  ASSERT_EQ(*state, IFTClient::NEEDS_PATCHES);
-
-  // Phase 3
-  patches = client->PatchesNeeded();
-  expected_patches = {"vf-0x03", "vf-0x04"};
-  ASSERT_EQ(patches, expected_patches);
-  sc = AddPatches(*client, encoder);
-  ASSERT_TRUE(sc.ok()) << sc;
-
-  state = client->Process();
-  ASSERT_TRUE(state.ok()) << state.status();
-  ASSERT_EQ(*state, IFTClient::READY);
-
-  // Checks
-
-  auto face = client->GetFontData().face();
-  ASSERT_GT(FontHelper::GvarData(face.get(), chunk0_gid)->size(), 0);
-  ASSERT_GT(FontHelper::GvarData(face.get(), chunk1_gid)->size(), 0);
-  ASSERT_EQ(FontHelper::GvarData(face.get(), chunk2_gid)->size(), 0);
-  ASSERT_GT(FontHelper::GvarData(face.get(), chunk3_gid)->size(), 0);
-  ASSERT_GT(FontHelper::GvarData(face.get(), chunk4_gid)->size(), 0);
+  ASSERT_GT(FontHelper::GvarData(extended_face.get(), chunk0_gid)->size(), 0);
+  ASSERT_GT(FontHelper::GvarData(extended_face.get(), chunk1_gid)->size(), 0);
+  ASSERT_EQ(FontHelper::GvarData(extended_face.get(), chunk2_gid)->size(), 0);
+  ASSERT_GT(FontHelper::GvarData(extended_face.get(), chunk3_gid)->size(), 0);
+  ASSERT_GT(FontHelper::GvarData(extended_face.get(), chunk4_gid)->size(), 0);
 }
-*/
 
 }  // namespace ift

--- a/ift/integration_test.cc
+++ b/ift/integration_test.cc
@@ -682,10 +682,9 @@ TEST_F(IntegrationTest, MixedMode_LocaLenChange) {
       !FontHelper::GlyfData(extended_face.get(), gid_count_3 - 1)->empty());
 }
 
-/*
 TEST_F(IntegrationTest, MixedMode_Complex) {
   Encoder encoder;
-  auto sc = InitEncoderForIftb(encoder);
+  auto sc = InitEncoderForMixedMode(encoder);
   ASSERT_TRUE(sc.ok()) << sc;
 
   // target paritions: {{0}, {1, 2}, {3, 4}}
@@ -696,58 +695,34 @@ TEST_F(IntegrationTest, MixedMode_Complex) {
 
   auto encoded = encoder.Encode();
   ASSERT_TRUE(encoded.ok()) << encoded.status();
-
-  auto client = IFTClient::NewClient(std::move(*encoded));
-  ASSERT_TRUE(client.ok()) << client.status();
+  auto encoded_face = encoded->face();
 
   // Phase 1
-  client->AddDesiredCodepoints({chunk1_cp});
-  auto state = client->Process();
-  ASSERT_TRUE(state.ok()) << state.status();
-  ASSERT_EQ(*state, IFTClient::NEEDS_PATCHES);
-
-  auto patches = client->PatchesNeeded();
-  ASSERT_EQ(patches.size(), 2);  // 1 shared brotli and 1 iftb.
-
-  sc = AddPatches(*client, encoder);
-  ASSERT_TRUE(sc.ok()) << sc;
-
-  state = client->Process();
-  ASSERT_TRUE(state.ok()) << state.status();
-  ASSERT_EQ(*state, IFTClient::READY);
+  auto extended = Extend(encoder, *encoded, {chunk1_cp});
+  ASSERT_TRUE(extended.ok()) << extended.status();
+  auto extended_face = extended->face();
 
   // Phase 2
-  client->AddDesiredCodepoints({chunk3_cp});
-  state = client->Process();
-  ASSERT_TRUE(state.ok()) << state.status();
-  ASSERT_EQ(*state, IFTClient::NEEDS_PATCHES);
-
-  patches = client->PatchesNeeded();
-  ASSERT_EQ(patches.size(), 2);  // 1 shared brotli and 1 iftb.
-
-  sc = AddPatches(*client, encoder);
-  ASSERT_TRUE(sc.ok()) << sc;
-
-  state = client->Process();
-  ASSERT_TRUE(state.ok()) << state.status();
-  ASSERT_EQ(*state, IFTClient::READY);
+  extended = Extend(encoder, *extended, {chunk1_cp, chunk3_cp});
+  ASSERT_TRUE(extended.ok()) << extended.status();
+  extended_face = extended->face();
 
   // Check the results
-  auto codepoints = ToCodepointsSet(client->GetFontData());
+  auto codepoints = FontHelper::ToCodepointsSet(extended_face.get());
   ASSERT_TRUE(codepoints.contains(chunk0_cp));
   ASSERT_TRUE(codepoints.contains(chunk1_cp));
   ASSERT_TRUE(codepoints.contains(chunk2_cp));
   ASSERT_TRUE(codepoints.contains(chunk3_cp));
   ASSERT_TRUE(codepoints.contains(chunk4_cp));
 
-  auto face = client->GetFontData().face();
-  ASSERT_TRUE(!FontHelper::GlyfData(face.get(), chunk0_gid)->empty());
-  ASSERT_TRUE(!FontHelper::GlyfData(face.get(), chunk1_gid)->empty());
-  ASSERT_FALSE(!FontHelper::GlyfData(face.get(), chunk2_gid)->empty());
-  ASSERT_TRUE(!FontHelper::GlyfData(face.get(), chunk3_gid)->empty());
-  ASSERT_FALSE(!FontHelper::GlyfData(face.get(), chunk4_gid)->empty());
+  ASSERT_TRUE(!FontHelper::GlyfData(extended_face.get(), chunk0_gid)->empty());
+  ASSERT_TRUE(!FontHelper::GlyfData(extended_face.get(), chunk1_gid)->empty());
+  ASSERT_FALSE(!FontHelper::GlyfData(extended_face.get(), chunk2_gid)->empty());
+  ASSERT_TRUE(!FontHelper::GlyfData(extended_face.get(), chunk3_gid)->empty());
+  ASSERT_FALSE(!FontHelper::GlyfData(extended_face.get(), chunk4_gid)->empty());
 }
 
+/*
 TEST_F(IntegrationTest, MixedMode_SequentialDependentPatches) {
   Encoder encoder;
   auto sc = InitEncoderForIftb(encoder);

--- a/third_party/fontations.BUILD
+++ b/third_party/fontations.BUILD
@@ -23,6 +23,7 @@ rust_binary(
       "@fontations_deps//:regex",
 	    ":incremental_font_transfer",
 	    ":skrifa",
+      ":klippa",
       ":read_fonts",
       ":font_types",
     ],
@@ -39,6 +40,7 @@ rust_library(
       ":write_fonts",
       ":skrifa",
       ":shared_brotli_patch_decoder",
+      ":klippa",
       "@fontations_deps//:data-encoding",
       "@fontations_deps//:data-encoding-macro",
       "@fontations_deps//:uri-template-system",
@@ -53,6 +55,20 @@ rust_library(
       "@fontations_deps//:bytemuck"
     ],
     crate_features = ["std", "bytemuck"],
+)
+
+rust_library(
+    name = "klippa",
+    srcs = glob(include = ["klippa/src/**/*.rs"]),
+    deps = [
+      ":skrifa",
+      ":write_fonts",
+      "@fontations_deps//:fnv",
+      "@fontations_deps//:hashbrown",
+      "@fontations_deps//:thiserror",
+      "@fontations_deps//:regex",
+    ],
+    # crate_features = ["std", "bytemuck"],
 )
 
 rust_library(
@@ -76,7 +92,7 @@ rust_library(
       "@fontations_deps//:log",
       "@fontations_deps//:indexmap",
     ],
-    crate_features = ["bytemuck", "std"],
+    crate_features = ["bytemuck", "std", "read"],
 )
 
 rust_library(


### PR DESCRIPTION
Uses fontations ift extension command line utility to simulate the client in the integration tests. The test suite currently demonstrates successful integration of mixed mode (glyph + table keyed) encoding use optional features and design space.